### PR TITLE
Switch to boto3 and allow to specify the host

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -86,7 +86,7 @@ Release 0.6
 
 6. New ``--get-bbox`` option to get the bbox of a tile.
 
-7. Add coveralls support (https://coveralls.io/r/sbrunner/tilecloud-chain).
+7. Add coveralls support (https://coveralls.io/r/camptocamp/tilecloud-chain).
 
 8. Add an config option ``generation:error_file`` and a command option ``--tiles``
    to store and regenerate errored tiles.

--- a/README.rst
+++ b/README.rst
@@ -542,7 +542,8 @@ The cache configuration is like this:
         hosts:
         - wmts0.<host>
 
-The bucket should already exists.
+The bucket should already exists. If you don't use Amazon's S3, you must specify the ``host`` and
+the ``tiles_url`` configuration parameter.
 
 Configure SQS
 -------------

--- a/README.rst
+++ b/README.rst
@@ -1,8 +1,8 @@
 TileCloud Chain
 ===============
 
-.. image:: https://secure.travis-ci.org/sbrunner/tilecloud-chain.svg?branch=master
-.. image:: https://coveralls.io/repos/sbrunner/tilecloud-chain/badge.png?branch=master
+.. image:: https://secure.travis-ci.org/camptocamp/tilecloud-chain.svg?branch=master
+.. image:: https://coveralls.io/repos/camptocamp/tilecloud-chain/badge.png?branch=master
 
 The goal of TileCloud Chain is to provide tools around tile generation on a chain like:
 
@@ -90,7 +90,7 @@ Install::
 
 Edit your layers configuration in ``./tilegeneration/config.yaml``.
 
-`Default configuration file <https://github.com/sbrunner/tilecloud-chain/blob/master/tilecloud_chain/scaffolds/create/tilegeneration/config.yaml.mako_tmpl>`_.
+`Default configuration file <https://github.com/camptocamp/tilecloud-chain/blob/master/tilecloud_chain/scaffolds/create/tilegeneration/config.yaml.mako_tmpl>`_.
 
 ---------
 Configure

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-tilecloud>=0.2dev-20130808
+tilecloud>=0.4.0
 psycopg2
 Shapely
 boto>=2.0

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
     ],
     author='Stéphane Brunner',
     author_email='stephane.brunner@camptocamp.com',
-    url='http://github.com/sbrunner/tilecloud-chain',
+    url='http://github.com/camptocamp/tilecloud-chain',
     license='BSD',
     keywords='gis tilecloud chain',
     packages=find_packages(exclude=["*.tests", "*.tests.*"]),

--- a/tilecloud_chain/__init__.py
+++ b/tilecloud_chain/__init__.py
@@ -212,7 +212,7 @@ class TileGeneration:
                 self.config['layers'][name] = c.validate()
 
         except SchemaError:
-            logger.error("The config file '{}' in invalid.\n{}".format(
+            logger.error("The config file '{}' is invalid.\n{}".format(
                 config_file,
                 "\n".join(sorted([
                     " - {}: {}".format(
@@ -224,12 +224,12 @@ class TileGeneration:
             ))
             exit(1)
         except NotSequenceError as e:  # pragma: no cover
-            logger.error("The config file '{}' in invalid.\n - {}".format(
+            logger.error("The config file '{}' is invalid.\n - {}".format(
                 config_file, e.msg
             ))
             exit(1)
         except NotMappingError as e:  # pragma: no cover
-            logger.error("The config file '{}' in invalid.\n - {}".format(
+            logger.error("The config file '{}' is invalid.\n - {}".format(
                 config_file, e.msg
             ))
             exit(1)
@@ -459,7 +459,8 @@ class TileGeneration:
         # store
         if cache['type'] == 's3':
             # on s3
-            cache_tilestore = S3TileStore(cache['bucket'], layout)  # pragma: no cover
+            cache_tilestore = S3TileStore(cache['bucket'], layout,
+                                          s3_host=cache.get('host'))  # pragma: no cover
         elif cache['type'] == 'mbtiles':
             # on mbtiles file
             filename = layout.filename(TileCoord(0, 0, 0)).replace(

--- a/tilecloud_chain/tests/apache.conf
+++ b/tilecloud_chain/tests/apache.conf
@@ -1,6 +1,6 @@
 ScriptAlias /mapserv /usr/lib/cgi-bin/mapserv
 <Location /mapserv>
    SetHandler fcgid-script
-   SetEnv MS_MAPFILE /home/travis/build/sbrunner/tilecloud-chain/tilecloud_chain/tests/mapfile/mapfile.map
+   SetEnv MS_MAPFILE /home/travis/build/camptocamp/tilecloud-chain/tilecloud_chain/tests/mapfile/mapfile.map
    Require all granted
 </Location>

--- a/tilecloud_chain/tests/test_error.py
+++ b/tilecloud_chain/tests/test_error.py
@@ -50,7 +50,7 @@ class TestError(CompareCase):
             cmd='.build/venv/bin/generate_controller -c tilegeneration/wrong_exists.yaml',
             main_func=controller.main)
         l.check(
-            ('tilecloud_chain', 'ERROR', """The config file 'tilegeneration/wrong_exists.yaml' in invalid.
+            ('tilecloud_chain', 'ERROR', """The config file 'tilegeneration/wrong_exists.yaml' is invalid.
  - /: Cannot find required key 'caches'.
  - /: Cannot find required key 'grids'.
  - /: Cannot find required key 'layers'."""),
@@ -63,7 +63,7 @@ class TestError(CompareCase):
             cmd='.build/venv/bin/generate_controller -v -c tilegeneration/wrong_type.yaml',
             main_func=controller.main)
         l.check((
-            'tilecloud_chain', 'ERROR', """The config file 'tilegeneration/wrong_type.yaml' in invalid.
+            'tilecloud_chain', 'ERROR', """The config file 'tilegeneration/wrong_type.yaml' is invalid.
  - /grids/swissgrid!/name: Value 'swissgrid!' does not match pattern '^[a-zA-Z0-9_\-~\.]+$'.
  - /grids/swissgrid!: Cannot find required key 'bbox'.
  - /grids/swissgrid!: Cannot find required key 'resolutions'.
@@ -122,7 +122,7 @@ class TestError(CompareCase):
             cmd='.build/venv/bin/generate_controller -c tilegeneration/wrong_srs_auth.yaml',
             main_func=controller.main)
         l.check((
-            'tilecloud_chain', 'ERROR', """The config file 'tilegeneration/wrong_srs_auth.yaml' in invalid.
+            'tilecloud_chain', 'ERROR', """The config file 'tilegeneration/wrong_srs_auth.yaml' is invalid.
  - /grids/swissgrid_01/srs: Value 'toto:21781' does not match pattern '^EPSG:[0-9]+$'."""  # noqa
         ))
 
@@ -133,7 +133,7 @@ class TestError(CompareCase):
             cmd='.build/venv/bin/generate_controller -c tilegeneration/wrong_srs_id.yaml',
             main_func=controller.main)
         l.check((
-            'tilecloud_chain', 'ERROR', """The config file 'tilegeneration/wrong_srs_id.yaml' in invalid.
+            'tilecloud_chain', 'ERROR', """The config file 'tilegeneration/wrong_srs_id.yaml' is invalid.
  - /grids/swissgrid_01/srs: Value 'EPSG:21781a' does not match pattern '^EPSG:[0-9]+$'."""  # noqa
         ))
 
@@ -144,7 +144,7 @@ class TestError(CompareCase):
             cmd='.build/venv/bin/generate_controller -c tilegeneration/wrong_srs.yaml',
             main_func=controller.main)
         l.check((
-            'tilecloud_chain', 'ERROR', """The config file 'tilegeneration/wrong_srs.yaml' in invalid.
+            'tilecloud_chain', 'ERROR', """The config file 'tilegeneration/wrong_srs.yaml' is invalid.
  - /grids/swissgrid_01/srs: Value 'EPSG21781' does not match pattern '^EPSG:[0-9]+$'."""
         ))
 
@@ -157,7 +157,7 @@ class TestError(CompareCase):
             cmd='.build/venv/bin/generate_controller -c tilegeneration/wrong_map.yaml',
             main_func=controller.main)
         l.check((
-            'tilecloud_chain', 'ERROR', """The config file 'tilegeneration/wrong_map.yaml' in invalid.
+            'tilecloud_chain', 'ERROR', """The config file 'tilegeneration/wrong_map.yaml' is invalid.
  - Value: test is not of a mapping type"""
         ))
 
@@ -169,7 +169,7 @@ class TestError(CompareCase):
             cmd='.build/venv/bin/generate_controller -c tilegeneration/wrong_sequence.yaml',
             main_func=controller.main)
         l.check((
-            'tilecloud_chain', 'ERROR', """The config file 'tilegeneration/wrong_sequence.yaml' in invalid.
+            'tilecloud_chain', 'ERROR', """The config file 'tilegeneration/wrong_sequence.yaml' is invalid.
  - /: Cannot find required key 'caches'.
  - /: Cannot find required key 'layers'.
  - /grids/test/resolutions: Value 'test' is not a list. Value path: '/grids/test/resolutions'


### PR DESCRIPTION
This was needed to use Exoscale's S3 clone.

Finish the switch to the camptocamp organisation.