### PR TITLE
Add tile generation log to database

### DIFF
--- a/tilecloud_chain/__init__.py
+++ b/tilecloud_chain/__init__.py
@@ -341,6 +341,60 @@ class TileGeneration:
         if layer_name and not error:
             self.set_layer(layer_name, options)
 
+        if 'logging' in self.config:
+            db_params = self.config['logging']['database']
+            self._db_connection = psycopg2.connect(
+                dbname=db_params['dbname'],
+                host=db_params.get('host'),
+                port=db_params.get('port')
+            )
+            if '.' in db_params['table']:
+                schema, table = db_params['table'].split('.')
+            else:
+                schema = 'public'
+                table = db_params['table']
+
+            self._logging_schema = psycopg2.extensions.quote_ident(schema, self._db_connection)
+            self._logging_table = psycopg2.extensions.quote_ident(table, self._db_connection)
+
+            with self._db_connection.cursor() as cursor:
+                cursor.execute(
+                    "SELECT EXISTS(SELECT 1 FROM pg_tables WHERE schemaname=%s AND tablename=%s)",
+                    (schema, table)
+                )
+                if not cursor.fetchone()[0]:
+                    try:
+                        cursor.execute(
+                            'CREATE TABLE {}.{} ('
+                            '  id SERIAL PRIMARY KEY,'
+                            '  layer CHARACTER VARYING(80) NOT NULL,'
+                            '  run INTEGER NOT NULL,'
+                            '  action CHARACTER VARYING(7) NOT NULL,'
+                            '  tile TEXT NOT NULL,'
+                            '  UNIQUE (layer, run, tile))'.format(self._logging_schema, self._logging_table)
+                        )
+                        self._db_connection.commit()
+                    except psycopg2.DatabaseError:
+                        logging.error('Unable to create table %s.%s', self._logging_schema, self._logging_table)
+                        error = True
+                else:
+                    try:
+                        cursor.execute(
+                            'INSERT INTO {}.{}(layer, run, action, tile) '
+                            'VALUES (%s, %s, %s, %s)'.format(self._logging_schema, self._logging_table),
+                            ('test_layer', -1, 'test', '-1x-1')
+                        )
+                    except psycopg2.DatabaseError:
+                        logging.error('Unable to insert logging data into %s.%s', self._logging_schema, self._logging_table)
+                        error = True
+                    finally:
+                        self._db_connection.rollback()
+        else:
+            self._db_connection = None
+
+        if error:
+            exit(1)
+
     def _primefactors(self, x):
         factorlist = []
         loop = 2

--- a/tilecloud_chain/schema.yaml
+++ b/tilecloud_chain/schema.yaml
@@ -364,3 +364,21 @@ mapping:
                     request:
                         type: float
                         default: .01
+    logging:
+      type: map
+      mapping:
+        database:
+          type: map
+          required: true
+          mapping:
+            host:
+              type: str
+            port:
+              type: int
+              default: 5432
+            dbname:
+              type: str
+              required: true
+            table:
+              type: str
+              required: true


### PR DESCRIPTION
This pull requests adds the logging of tile generation to a database. The database and table are configured in the yaml configuration file. Only the dbname and table (which can include a schema, no schema implies `public`) are required. The other options (host and port) default to the psycopg2 defaults of a local unix socket on port 5432.

When starting the tile generator, if there is a database configured for logging, it makes sure the table will be able to receive the logging data. If there is an error in creating the table or inserting a dummy log entry (that is rolled back on success), the generator exits immediately.

As the generator creates tiles, the logger inserts and updates the logging table. Each logger (created whenever `TileGeneration.set_layer` is called) manages its own run of logging events.

Fixes #278 