### PR TITLE
Add logging before dropping the error tiles

### DIFF
--- a/tilecloud_chain/__init__.py
+++ b/tilecloud_chain/__init__.py
@@ -741,7 +741,7 @@ class TileGeneration:
 
             self.error_file.write('{}# [{}]{}\n'.format(tilecoord, time, message.replace('\n', ' ')))
 
-    def add_error_filters(self):
+    def add_error_filters(self, queue_store=None):
         self.imap(LogErrors(
             logger, logging.ERROR,
             "Error in tile: %(tilecoord)s, %(error)r"
@@ -760,6 +760,8 @@ class TileGeneration:
 
         def drop_count(tile):
             if tile and tile.error:
+                if queue_store is not None:
+                    queue_store.delete_one(tile)
                 self.error += 1
                 return None
             return tile

--- a/tilecloud_chain/database_logger.py
+++ b/tilecloud_chain/database_logger.py
@@ -103,11 +103,9 @@ class DatabaseLogger(DatabaseLoggerCommon):  # pragma: no cover
             try:
                 cursor.execute(
                     'INSERT INTO {} (layer, run, action, tile)'
-                    'VALUES (%(layer)s, %(run)s, %(action)s::varchar(7), %(tile)s)'
-                    'RETURNING run'.format(self.full_table),
+                    'VALUES (%(layer)s, %(run)s, %(action)s::varchar(7), %(tile)s)'.format(self.full_table),
                     {'layer': layer, 'action': action, 'tile': str(tile.tilecoord), 'run': run}
                 )
-                self.run, = cursor.fetchone()
             except psycopg2.IntegrityError:
                 self.connection.rollback()
                 cursor.execute(

--- a/tilecloud_chain/generate.py
+++ b/tilecloud_chain/generate.py
@@ -151,7 +151,9 @@ class Generate:
             gene.imap(wrong_content_type_to_error)
             if options.role in ('local', 'slave') and 'logging' in gene.config:
                 gene.imap(DatabaseLogger(gene.config['logging'], options is not None and options.daemon))
-            gene.add_error_filters(self.sqs_tilestore)
+                gene.add_error_filters(self.sqs_tilestore)
+            else:
+                gene.add_error_filters()
 
             if options.role == 'hash':
                 if gene.layer.get('meta', False):

--- a/tilecloud_chain/generate.py
+++ b/tilecloud_chain/generate.py
@@ -149,7 +149,9 @@ class Generate:
                         )
                 return tile
             gene.imap(wrong_content_type_to_error)
-            gene.add_error_filters()
+            if options.role in ('local', 'slave') and 'logging' in gene.config:
+                gene.imap(DatabaseLogger(gene.config['logging'], options is not None and options.daemon))
+            gene.add_error_filters(self.sqs_tilestore)
 
             if options.role == 'hash':
                 if gene.layer.get('meta', False):


### PR DESCRIPTION
This PR adds database logging before the tiles with download errors are removed from the tilestream. This allows the logger to see the tiles which failed to download. To remove the tiles from the sqs store, add_error_filter can receive a queue store. If it gets one, it will remove the broken tiles from the queue as it removes them from the tilestream

Fixes #294 