### PR TITLE
Set the ServiceIdentification element in WMTS Capabilities

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,12 @@ Changelog
 =========
 
 -----------
+Release 1.4
+-----------
+
+1. Add optional ``metadata`` section to the config file. See the scaffolds for example.
+
+-----------
 Release 0.9
 -----------
 

--- a/tilecloud_chain/__init__.py
+++ b/tilecloud_chain/__init__.py
@@ -179,6 +179,8 @@ class TileGeneration:
                 self.config['cost']['sqs'] = {}
         if 'generation' not in self.config:
             self.config['generation'] = {}
+        if 'metadata' not in self.config:
+            self.config['metadata'] = {}
         for gname, grid in sorted(self.config.get('grids', {}).items()):
             if grid is not None:
                 grid["name"] = gname
@@ -304,6 +306,7 @@ class TileGeneration:
                 error = True
 
         self.caches = self.config['caches']
+        self.metadata = self.config['metadata']
 
         if error:
             exit(1)

--- a/tilecloud_chain/controller.py
+++ b/tilecloud_chain/controller.py
@@ -207,7 +207,7 @@ def _generate_wmts_capabilities(gene):
         base_url_postfix='wmts/' if server else '',
         get_tile_matrix_identifier=get_tile_matrix_identifier,
         server=server,
-        title=gene.metadata['title'] if 'title' in gene.metadata else None,
+        metadata=gene.metadata,
         enumerate=enumerate, ceil=math.ceil, int=int, sorted=sorted,
     )
     _send(capabilities, cache['wmtscapabilities_file'], 'application/xml', cache)

--- a/tilecloud_chain/controller.py
+++ b/tilecloud_chain/controller.py
@@ -207,6 +207,7 @@ def _generate_wmts_capabilities(gene):
         base_url_postfix='wmts/' if server else '',
         get_tile_matrix_identifier=get_tile_matrix_identifier,
         server=server,
+        title=gene.metadata['title'] if 'title' in gene.metadata else None,
         enumerate=enumerate, ceil=math.ceil, int=int, sorted=sorted,
     )
     _send(capabilities, cache['wmtscapabilities_file'], 'application/xml', cache)

--- a/tilecloud_chain/scaffolds/create/tilegeneration/config.yaml.mako_tmpl
+++ b/tilecloud_chain/scaffolds/create/tilegeneration/config.yaml.mako_tmpl
@@ -134,3 +134,6 @@ openlayers:
     srs: EPSG:21781
     center_x: 600000
     center_y: 200000
+
+metadata:
+    title: Some title

--- a/tilecloud_chain/scaffolds/create/tilegeneration/config.yaml.mako_tmpl
+++ b/tilecloud_chain/scaffolds/create/tilegeneration/config.yaml.mako_tmpl
@@ -137,3 +137,4 @@ openlayers:
 
 metadata:
     title: Some title
+    servicetype: OGC WMTS

--- a/tilecloud_chain/schema.yaml
+++ b/tilecloud_chain/schema.yaml
@@ -364,6 +364,11 @@ mapping:
                     request:
                         type: float
                         default: .01
+    metadata:
+        type: map
+        mapping:
+            title:
+                type: str
     logging:
       type: map
       mapping:

--- a/tilecloud_chain/schema.yaml
+++ b/tilecloud_chain/schema.yaml
@@ -369,6 +369,9 @@ mapping:
         mapping:
             title:
                 type: str
+            servicetype:
+                type: str
+                default: OGC WMTS
     logging:
       type: map
       mapping:

--- a/tilecloud_chain/tests/test_controller.py
+++ b/tilecloud_chain/tests/test_controller.py
@@ -1951,7 +1951,7 @@ mapcache: {config_file: mapcache.xml, memcache_host: localhost, memcache_port: 1
 openlayers: {center_x: 600000, center_y: 200000, srs: 'EPSG:21781'}
 sqs: {queue: sqs_point, region: eu-west-1}
 sns: {region: eu-west-1, topic: 'arn:aws:sns:eu-west-1:your-account-id:tilecloud'}
-metadata: {title: 'Some title'}"""
+metadata: {servicetype: 'OGC WMTS', title: 'Some title'}"""
 
     @attr(general=True)
     def test_config(self):

--- a/tilecloud_chain/tests/test_controller.py
+++ b/tilecloud_chain/tests/test_controller.py
@@ -41,8 +41,11 @@ class TestController(CompareCase):
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns:gml="http://www.opengis.net/gml"
     xsi:schemaLocation="http://schemas.opengis.net/wmts/1.0/wmtsGetCapabilities_response.xsd">
-  <ows:ServiceIdentification> </ows:ServiceIdentification>
-  <ows:ServiceProvider> </ows:ServiceProvider>
+  <ows:ServiceIdentification>
+    <ows:Title>Some title</ows:Title>
+    <ows:ServiceType>OGC WMTS</ows:ServiceType>
+    <ows:ServiceTypeVersion>1.0.0</ows:ServiceTypeVersion>
+  </ows:ServiceIdentification>
   <ows:OperationsMetadata>
     <ows:Operation name="GetCapabilities">
       <ows:DCP>
@@ -449,8 +452,11 @@ class TestController(CompareCase):
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns:gml="http://www.opengis.net/gml"
     xsi:schemaLocation="http://schemas.opengis.net/wmts/1.0/wmtsGetCapabilities_response.xsd">
-  <ows:ServiceIdentification> </ows:ServiceIdentification>
-  <ows:ServiceProvider> </ows:ServiceProvider>
+  <ows:ServiceIdentification>
+    <ows:Title>Some title</ows:Title>
+    <ows:ServiceType>OGC WMTS</ows:ServiceType>
+    <ows:ServiceTypeVersion>1.0.0</ows:ServiceTypeVersion>
+  </ows:ServiceIdentification>
   <ows:OperationsMetadata>
     <ows:Operation name="GetCapabilities">
       <ows:DCP>
@@ -954,8 +960,6 @@ class TestController(CompareCase):
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns:gml="http://www.opengis.net/gml"
     xsi:schemaLocation="http://schemas.opengis.net/wmts/1.0/wmtsGetCapabilities_response.xsd">
-  <ows:ServiceIdentification> </ows:ServiceIdentification>
-  <ows:ServiceProvider> </ows:ServiceProvider>
   <ows:OperationsMetadata>
     <ows:Operation name="GetCapabilities">
       <ows:DCP>
@@ -1946,7 +1950,8 @@ layers:
 mapcache: {config_file: mapcache.xml, memcache_host: localhost, memcache_port: 11211, location: /mapcache}
 openlayers: {center_x: 600000, center_y: 200000, srs: 'EPSG:21781'}
 sqs: {queue: sqs_point, region: eu-west-1}
-sns: {region: eu-west-1, topic: 'arn:aws:sns:eu-west-1:your-account-id:tilecloud'}"""
+sns: {region: eu-west-1, topic: 'arn:aws:sns:eu-west-1:your-account-id:tilecloud'}
+metadata: {title: 'Some title'}"""
 
     @attr(general=True)
     def test_config(self):
@@ -2175,8 +2180,6 @@ OpenLayers.Request.GET({
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns:gml="http://www.opengis.net/gml"
     xsi:schemaLocation="http://schemas.opengis.net/wmts/1.0/wmtsGetCapabilities_response.xsd">
-  <ows:ServiceIdentification> </ows:ServiceIdentification>
-  <ows:ServiceProvider> </ows:ServiceProvider>
   <ows:OperationsMetadata>
     <ows:Operation name="GetCapabilities">
       <ows:DCP>

--- a/tilecloud_chain/tests/test_serve.py
+++ b/tilecloud_chain/tests/test_serve.py
@@ -23,8 +23,6 @@ CAPABILITIES = """<\?xml version="1.0" encoding="UTF-8"\?>
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns:gml="http://www.opengis.net/gml"
     xsi:schemaLocation="http://schemas.opengis.net/wmts/1.0/wmtsGetCapabilities_response.xsd">
-  <ows:ServiceIdentification> </ows:ServiceIdentification>
-  <ows:ServiceProvider> </ows:ServiceProvider>
   <ows:OperationsMetadata>
     <ows:Operation name="GetCapabilities">
       <ows:DCP>
@@ -280,8 +278,6 @@ Size per tile: 4[0-9][0-9] o
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns:gml="http://www.opengis.net/gml"
     xsi:schemaLocation="http://schemas.opengis.net/wmts/1.0/wmtsGetCapabilities_response.xsd">
-  <ows:ServiceIdentification> </ows:ServiceIdentification>
-  <ows:ServiceProvider> </ows:ServiceProvider>
   <ows:OperationsMetadata>
     <ows:Operation name="GetCapabilities">
       <ows:DCP>

--- a/tilecloud_chain/tests/tilegeneration/test-fix.yaml
+++ b/tilecloud_chain/tests/tilegeneration/test-fix.yaml
@@ -258,3 +258,6 @@ apache:
 sns:
     topic: arn:aws:sns:eu-west-1:your-account-id:tilecloud
     region: eu-west-1
+
+metadata:
+    title: Some title

--- a/tilecloud_chain/wmts_get_capabilities.jinja
+++ b/tilecloud_chain/wmts_get_capabilities.jinja
@@ -5,9 +5,14 @@
     xmlns:xlink="http://www.w3.org/1999/xlink"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns:gml="http://www.opengis.net/gml"
-    xsi:schemaLocation="http://schemas.opengis.net/wmts/1.0/wmtsGetCapabilities_response.xsd">
-  <ows:ServiceIdentification> </ows:ServiceIdentification>
-  <ows:ServiceProvider> </ows:ServiceProvider>
+    xsi:schemaLocation="http://schemas.opengis.net/wmts/1.0/wmtsGetCapabilities_response.xsd">{%
+  if title %}
+  <ows:ServiceIdentification>
+    <ows:Title>{{title}}</ows:Title>
+    <ows:ServiceType>OGC WMTS</ows:ServiceType>
+    <ows:ServiceTypeVersion>1.0.0</ows:ServiceTypeVersion>
+  </ows:ServiceIdentification>{%
+  endif %}
   <ows:OperationsMetadata>
     <ows:Operation name="GetCapabilities">
       <ows:DCP>

--- a/tilecloud_chain/wmts_get_capabilities.jinja
+++ b/tilecloud_chain/wmts_get_capabilities.jinja
@@ -6,10 +6,10 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns:gml="http://www.opengis.net/gml"
     xsi:schemaLocation="http://schemas.opengis.net/wmts/1.0/wmtsGetCapabilities_response.xsd">{%
-  if title %}
+  if 'title' in metadata and metadata['title'] %}
   <ows:ServiceIdentification>
-    <ows:Title>{{title}}</ows:Title>
-    <ows:ServiceType>OGC WMTS</ows:ServiceType>
+    <ows:Title>{{metadata['title']}}</ows:Title>
+    <ows:ServiceType>{{metadata['servicetype']}}</ows:ServiceType>
     <ows:ServiceTypeVersion>1.0.0</ows:ServiceTypeVersion>
   </ows:ServiceIdentification>{%
   endif %}


### PR DESCRIPTION
Related to https://github.com/camptocamp/tilecloud-chain/issues/322

This PR:
* adds mandatory child elements to the ``<ows:ServiceIdentification>`` element in WMTS Capabilities with a configurable ``title`` data.
* removes the optional ``<ows:ServiceProvider>`` (it could be added back later with configurable data as for ``<ows:ServiceIdentification>`` if really needed)

Questions:
* should we add the new ``metadata`` section in https://github.com/camptocamp/tilecloud-chain/blob/master/tilecloud_chain/scaffolds/create/tilegeneration/config.yaml.mako_tmpl ?
* should we add it to some changelog?