### PR TITLE
Moved the min python version to 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ dist: trusty
 language: python
 
 python:
-- 3.4
+- 3.5
 - 3.6
 
 env:


### PR DESCRIPTION
Some libs we depend on are tested only for 3.5.