### PR TITLE
Be more flexible with the redis URL config

### DIFF
--- a/tilecloud_chain/schema.yaml
+++ b/tilecloud_chain/schema.yaml
@@ -280,7 +280,7 @@ mapping:
             url:
                 type: str
                 required: true
-                pattern: ^redis://[^:]+:\d+$
+                pattern: ^redis://[^:]+:[^:]+$
             queue:
                 type: str
                 default: tilecloud


### PR DESCRIPTION
This is needed in c2cgeoportal when we generate the controllers. At
that moment, the redis URL may look like that:
`redis://${REDIS_HOST}:${REDIS_PORT}`