### PR TITLE
Fix 100% CPU when DB is lost

### DIFF
--- a/tilecloud_chain/__init__.py
+++ b/tilecloud_chain/__init__.py
@@ -687,26 +687,10 @@ class TileGeneration:
         store = TimedTileStoreWrapper(MultiTileStore(splitters), stats_name='splitter')
 
         def meta_get(tilestream):  # pragma: no cover
-            try:
-                for metatile in tilestream:
-                    substream = store.get((metatile,))
-                    try:
-                        for tile in substream:
-                            yield tile
-                    except StopIteration:
-                        return
-                    except RuntimeError as e:
-                        if isinstance(e.__cause__, StopIteration):
-                            # since python 3.7, a StopIteration is wrapped in a RuntimeError (PEP 479)
-                            return
-                        else:
-                            raise
-            except RuntimeError as e:
-                if isinstance(e.__cause__, StopIteration):
-                    logger.warning("StopIterator from hell", exc_info=True)
-                    return
-                else:
-                    raise
+            for metatile in tilestream:
+                substream = store.get((metatile,))
+                for tile in substream:
+                    yield tile
 
         self.tilestream = meta_get(self.tilestream)  # pragma: no cover
 

--- a/tilecloud_chain/timedtilestore.py
+++ b/tilecloud_chain/timedtilestore.py
@@ -24,6 +24,12 @@ class TimedTileStoreWrapper(TileStore):
                 tile = next(generator)
             except StopIteration:
                 break
+            except RuntimeError as e:
+                if isinstance(e.__cause__, StopIteration):
+                    # since python 3.7, a StopIteration is wrapped in a RuntimeError (PEP 479)
+                    break
+                else:
+                    raise
             timer.stop(self._get_stats_name(func_name, tile))
             yield tile
 


### PR DESCRIPTION
Instead of using 100% CPU and not being able to recover in case of error
(DB loss, for example), tilecloud now exists. We count on the
orchestrator or systemd to restart the service.

Closes #423