### PR TITLE
The authorised_user should not be checked for slaves

### DIFF
--- a/tilecloud_chain/generate.py
+++ b/tilecloud_chain/generate.py
@@ -467,7 +467,7 @@ def main():
 
     gene = TileGeneration(options.config, options)
 
-    if options.get_hash is None and options.get_bbox is None and \
+    if options.get_hash is None and options.get_bbox is None and options.role != "slave" and \
             'authorised_user' in gene.config['generation'] and \
             gene.config['generation']['authorised_user'] != getuser():
         exit('not authorised, authorised user is: {}.'.format(gene.config['generation']['authorised_user']))


### PR DESCRIPTION
This breaks the slave in OpenShift:
```
Traceback (most recent call last):
 File "/usr/local/bin/generate_tiles", line 11, in <module>
   load_entry_point('tilecloud-chain', 'console_scripts', 'generate_tiles')()
 File "/app/tilecloud_chain/generate.py", line 468, in main
   gene.config['generation']['authorised_user'] != getuser():
 File "/usr/lib/python3.7/getpass.py", line 169, in getuser
   return pwd.getpwuid(os.getuid())[0]
KeyError: 'getpwuid(): uid not found: 1000270000'
```