### PR TITLE
Upgrade tilecloud to 1.3.4

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,3 +60,4 @@ test:
     - redis
   volumes:
     - ./tilecloud_chain:/app/tilecloud_chain
+    # - ../tilecloud/tilecloud:/usr/local/lib/python3.7/dist-packages/tilecloud

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,5 @@ PyYAML==5.1.2
 redlock-py==1.0.8
 Shapely==1.6.4.post2
 testfixtures==6.10.0
-tilecloud==1.3.2
+tilecloud==1.3.4
 unittest2==1.1.0


### PR DESCRIPTION
This is to try to reduce memory usage of the tilecloud-chain server. It
will reduce the number of connections to S3.