### PR TITLE
Fix static path test

### DIFF
--- a/tilecloud_chain/server.py
+++ b/tilecloud_chain/server.py
@@ -190,7 +190,7 @@ class Server:
         metadata = {}
 
         if path:
-            if path[:len(self.static_path)] == self.static_path:
+            if tuple(path[:len(self.static_path)]) == tuple(self.static_path):
                 body, mime = self._get('/'.join(path[len(self.static_path):]), **kwargs)
                 if mime is not None:
                     return self.response(body, {


### PR DESCRIPTION
As self.request.matchdict['path'] returns a tuple which cannot equal a list.