### PR TITLE
Set a ttl for tiles stored in Redis

### DIFF
--- a/tilecloud_chain/schema.yaml
+++ b/tilecloud_chain/schema.yaml
@@ -301,6 +301,9 @@ mapping:
             prefix:
                 type: str
                 default: tilecloud_cache
+            expiration:
+                type: int
+                default: 28800  # 8h
 
     apache:
         type: map


### PR DESCRIPTION
I've picked by default the same TTL we had in mapcache (was hardcoded).

This is needed for
https://github.com/camptocamp/private-geo-charts/pull/26 and to make the
internal mapcache behavior compatible with the external one.