### PR TITLE
Better renovate configuration

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -5,7 +5,7 @@ updates:
   - package-ecosystem: pip
     directory: '/'
     schedule:
-      interval: daily
+      interval: weekly
     ignore:
       - dependency-name: none
     allow:

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,10 +1,15 @@
 {
-  "extends": ["config:base"],
-  "baseBranches": ["master", "1.17", "1.15", "1.13"],
+  "extends": ["config:base", "schedule:earlyMondays"],
+  "baseBranches": ["master", "1.17"],
   "packageRules": [
     {
       "matchBaseBranches": ["master"],
-      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "automerge": true
+    },
+    {
+      "matchUpdateTypes": ["patch"],
+      "groupName": "patch",
       "automerge": true
     },
     {
@@ -13,16 +18,7 @@
     },
     {
       "branchPrefix": ["1."],
-      "matchUpdateTypes": [
-        "major",
-        "minor",
-        "patch",
-        "pin",
-        "digest",
-        "lockFileMaintenance",
-        "rollback",
-        "bump"
-      ],
+      "matchUpdateTypes": ["major", "minor", "pin", "digest", "lockFileMaintenance", "rollback", "bump"],
       "enabled": false
     }
   ]

--- a/.github/workflows/dependabot-auto-merge.yaml
+++ b/.github/workflows/dependabot-auto-merge.yaml
@@ -1,5 +1,5 @@
 ---
-name: Auto merge Dependabot updates
+name: Auto reviews updates
 
 on:
   workflow_run:
@@ -10,12 +10,14 @@ on:
 
 jobs:
   auto-merge:
-    name: Auto merge Dependabot updates
+    name: Auto reviews updates
     runs-on: ubuntu-20.04
     timeout-minutes: 5
 
     steps:
-      - name: Auto merge
-        uses: ridedott/dependabot-auto-merge-action@master
+      - name: Auto reviews updates
+        uses: golfzaptw/action-auto-reviews-from-branches@master
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCHES: master
+          AUTHOR: dependabot[bot],renovatebot


### PR DESCRIPTION
Globally, the configuration say:
- weekly updates
- on branch master and 1.17
- on master the minor and patch will be automatically merged
- the dev dependency will be automatically merged
- on stabilization branches, we will have only the patch updates
- group patch update

Advantages from Dependabot:
- manage the stabilization branches
- manage the dependency from helm, docker-compose, CDN, ...
- cleaner configuration