### PR TITLE
Add tile information in JSON logs

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -16,7 +16,7 @@ jobs:
   main:
     runs-on: ubuntu-22.04
     name: Continuous integration
-    timeout-minutes: 20
+    timeout-minutes: 30
     if: "!startsWith(github.event.head_commit.message, '[skip ci] ')"
 
     env:

--- a/development.ini
+++ b/development.ini
@@ -73,6 +73,6 @@ formatter = generic
 format = %(levelname)-5.5s %(name)s %(message)s
 
 [handler_json]
-class = c2cwsgiutils.pyramid_logging.JsonLogHandler
+class = tilecloud_chain.JsonLogHandler
 args = (sys.stdout,)
 level = NOTSET

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -76,6 +76,7 @@ services:
       SERVER_NB_THREAD: 2
       TILECLOUD_LOG_LEVEL: DEBUG
       TILECLOUD_CHAIN_LOG_LEVEL: DEBUG
+      TILECLOUD_CHAIN_SESSION_SALT: a-long-secret-a-long-secret
     command:
       - sleep
       - infinity

--- a/gunicorn.conf.py
+++ b/gunicorn.conf.py
@@ -49,7 +49,7 @@ logconfig_dict = {
             "stream": "ext://sys.stdout",
         },
         "json": {
-            "class": "c2cwsgiutils.pyramid_logging.JsonLogHandler",
+            "class": "tilecloud_chain.JsonLogHandler",
             "formatter": "generic",
             "stream": "ext://sys.stdout",
         },

--- a/tilecloud_chain/views/admin.py
+++ b/tilecloud_chain/views/admin.py
@@ -143,7 +143,11 @@ class Admin:
                     )
                 }
 
-        final_command = [command, f"--config={self.gene.get_host_config_file(self.request.host)}"]
+        final_command = [
+            command,
+            f"--host={self.request.host}",
+            f"--config={self.gene.get_host_config_file(self.request.host)}",
+        ]
         if add_role:
             final_command += ["--role=master"]
         final_command += commands[1:]


### PR DESCRIPTION
Special note for the host way:
- Set by the server in the `--host` argument of the `generate-controller`command.
- Set in the tile metadata (that go throws Redis)
- Set in a global variable `tilecloud_chain.LOGGING_CONTEXT`
- Set in the JSON log information