### PR TITLE
Fix CVE

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -157,11 +157,11 @@ python-versions = "*"
 
 [[package]]
 name = "certifi"
-version = "2021.10.8"
+version = "2022.12.7"
 description = "Python package for providing Mozilla's CA Bundle."
 category = "main"
 optional = false
-python-versions = "*"
+python-versions = ">=3.6"
 
 [[package]]
 name = "cffi"
@@ -1499,7 +1499,7 @@ test = ["zope.testing"]
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.8,<3.11"
-content-hash = "d16f534a852c503cdd6f008bc1ce7c7eaeb318ee7e33c0ea0696cf154f770b43"
+content-hash = "5dfcf6bf97e6a0bca5f3956c2233dd063be555834317d7f13c3a0f803c9829d3"
 
 [metadata.files]
 astroid = [
@@ -1550,8 +1550,8 @@ cee-syslog-handler = [
     {file = "cee_syslog_handler-0.6.0.tar.gz", hash = "sha256:babeb63d70a2d8deba734fff5ad3723fed6d053a01621a19937f900315813e0b"},
 ]
 certifi = [
-    {file = "certifi-2021.10.8-py2.py3-none-any.whl", hash = "sha256:d62a0163eb4c2344ac042ab2bdf75399a71a2d8c7d47eac2e2ee91b9d6339569"},
-    {file = "certifi-2021.10.8.tar.gz", hash = "sha256:78884e7c1d4b00ce3cea67b44566851c4343c120abd683433ce934a68ea58872"},
+    {file = "certifi-2022.12.7-py3-none-any.whl", hash = "sha256:4ad3232f5e926d6718ec31cfc1fcadfde020920e278684144551c91769c7bc18"},
+    {file = "certifi-2022.12.7.tar.gz", hash = "sha256:35824b4c3a97115964b408844d64aa14db1cc518f6562e8d7261699d1350a9e3"},
 ]
 cffi = [
     {file = "cffi-1.15.0-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:c2502a1a03b6312837279c8c1bd3ebedf6c12c4228ddbad40912d671ccc8a962"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ mako = "1.2.4"
 oauthlib = "3.2.2"
 cryptography = "38.0.4"
 Pillow = "9.3.0"
+certifi = "2022.12.7"
 
 [tool.poetry.dev-dependencies]
 coverage = "6.3.3"


### PR DESCRIPTION
    Pin certifi@2021.10.8 to certifi@2022.12.7 to fix
    ✗ Insufficient Verification of Data Authenticity (new) [Medium Severity][https://security.snyk.io/vuln/SNYK-PYTHON-CERTIFI-3164749] in certifi@2021.10.8
      introduced by sentry-sdk@1.5.12 > certifi@2021.10.8 and 14 other path(s)