### PR TITLE
Improve WMTS REST dimension error reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Add a Pydantic-based settings hierarchy for environment variables.
 - Update server, queue, admin, and generation code to read configuration from `tilecloud_chain.settings`.
 - Document the new nested environment variable scheme in `tilecloud_chain/USAGE.rst`.
-- Improve WMTS REST error messages for invalid dimension paths by returning a 400 with missing, empty, or unexpected dimension details instead of a server error.
+- Improve WMTS REST error messages for invalid dimensions by returning a 400 with missing, empty, unexpected, or not-allowed dimension values instead of a server error.
 
 Environment variable migration (legacy -> new)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Add a Pydantic-based settings hierarchy for environment variables.
 - Update server, queue, admin, and generation code to read configuration from `tilecloud_chain.settings`.
 - Document the new nested environment variable scheme in `tilecloud_chain/USAGE.rst`.
+- Improve WMTS REST error messages for invalid dimension paths by returning a 400 with missing, empty, or unexpected dimension details instead of a server error.
 
 Environment variable migration (legacy -> new)
 

--- a/tilecloud_chain/server.py
+++ b/tilecloud_chain/server.py
@@ -142,6 +142,25 @@ def _add_dimensions_to_params(
             ),
         )
 
+    wrong_dimensions = [
+        (
+            expected_dimension_names[index],
+            value,
+            dimensions[index]["values"],
+        )
+        for index, value in enumerate(provided_dimension_values)
+        if value not in dimensions[index]["values"]
+    ]
+    if wrong_dimensions:
+        details = [
+            (f"{name}='{value}' not in allowed values ({', '.join(expected_values)})")
+            for name, value, expected_values in wrong_dimensions
+        ]
+        raise HTTPException(
+            status_code=400,
+            detail=f"Wrong dimensions for layer '{layer}': {'; '.join(details)}",
+        )
+
     for index, dimension in enumerate(dimensions):
         params[dimension["name"].upper()] = provided_dimension_values[index]
 

--- a/tilecloud_chain/server.py
+++ b/tilecloud_chain/server.py
@@ -103,6 +103,49 @@ _LEGEND_CONFIG_CACHE: dict[str, LegendLayerCache] = {}
 _LEGEND_CONFIG_CACHE_LOCK: asyncio.Lock | None = None
 
 
+def _add_dimensions_to_params(
+    params: dict[str, str],
+    layer: str,
+    dimensions: list[tilecloud_chain.configuration.LayerDimensionsItem],
+    dimensions_parameters: str,
+) -> None:
+    expected_dimension_names = [dimension["name"] for dimension in dimensions]
+    provided_dimension_values = dimensions_parameters.split("/")
+
+    if len(provided_dimension_values) != len(expected_dimension_names):
+        details = [
+            f"expected {len(expected_dimension_names)} value(s) ({', '.join(expected_dimension_names)})",
+            f"got {len(provided_dimension_values)} value(s) ({', '.join(provided_dimension_values)})",
+        ]
+        if len(provided_dimension_values) < len(expected_dimension_names):
+            missing_dimensions = expected_dimension_names[len(provided_dimension_values) :]
+            details.append(f"missing dimension(s): {', '.join(missing_dimensions)}")
+        else:
+            unexpected_values = provided_dimension_values[len(expected_dimension_names) :]
+            details.append(f"unexpected value(s): {', '.join(unexpected_values)}")
+        raise HTTPException(
+            status_code=400,
+            detail=f"Wrong dimensions for layer '{layer}': {'; '.join(details)}",
+        )
+
+    empty_dimensions = [
+        expected_dimension_names[index]
+        for index, value in enumerate(provided_dimension_values)
+        if value == ""
+    ]
+    if empty_dimensions:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"Wrong dimensions for layer '{layer}': "
+                f"empty value(s) for dimension(s): {', '.join(empty_dimensions)}"
+            ),
+        )
+
+    for index, dimension in enumerate(dimensions):
+        params[dimension["name"].upper()] = provided_dimension_values[index]
+
+
 async def init_tilegeneration(config_file: Path | None) -> None:
     """Initialize the tile generation."""
     global _TILEGENERATION  # noqa: PLW0603
@@ -862,9 +905,7 @@ async def wmts_feature_info(
 
     dimensions: list[tilecloud_chain.configuration.LayerDimensionsItem] = layer_obj.get("dimensions", [])
     if dimensions:
-        dimensions_parameters_list = dimensions_parameters.split("/")
-        for index, dimension in enumerate(dimensions):
-            params[dimension["name"].upper()] = dimensions_parameters_list[index]
+        _add_dimensions_to_params(params, layer, dimensions, dimensions_parameters)
 
     return await server.serve(params, config, host, request)
 
@@ -922,9 +963,7 @@ async def wmts_tile(
 
     dimensions: list[tilecloud_chain.configuration.LayerDimensionsItem] = layer_obj.get("dimensions", [])
     if dimensions:
-        dimensions_parameters_list = dimensions_parameters.split("/")
-        for index, dimension in enumerate(dimensions):
-            params[dimension["name"].upper()] = dimensions_parameters_list[index]
+        _add_dimensions_to_params(params, layer, dimensions, dimensions_parameters)
 
     if extension == "webp":
         params["FORMAT"] = "image/webp"

--- a/tilecloud_chain/tests/test_serve.py
+++ b/tilecloud_chain/tests/test_serve.py
@@ -1143,7 +1143,15 @@ class TestServe(CompareCase):
                 "got 2 value(s) (2012, extra); unexpected value(s): extra"
             )
 
-            # 6. GetCapabilities
+            # 6. GetTile with wrong dimensions value
+            response = client.get("/tiles/1.0.0/point_hash/default/20231011/swissgrid_5/1/11/14.png")
+            assert response.status_code == 400
+            assert response.json()["detail"] == (
+                "Wrong dimensions for layer 'point_hash': "
+                "DATE='20231011' not in allowed values (2005, 2010, 2012)"
+            )
+
+            # 7. GetCapabilities
             response = client.get("/tiles/1.0.0/WMTSCapabilities.xml")
             assert response.status_code == 200
             assert response.headers["Content-Type"] == "application/xml"

--- a/tilecloud_chain/tests/test_serve.py
+++ b/tilecloud_chain/tests/test_serve.py
@@ -828,7 +828,6 @@ class TestServe(CompareCase):
     async def test_bsddb_rest(self):
         with LogCapture("tilecloud_chain", level=30) as log_capture:
             await self.assert_tiles_generated(
-
                 cmd=".build/venv/bin/generate-tiles -d --config=tilegeneration/test-bsddb.yaml"
                 " --layer=point_hash --zoom=1",
                 main_func=generate.async_main,
@@ -1065,17 +1064,18 @@ class TestServe(CompareCase):
 
         async def get_one_side_effect(tile):
             if tile.tilecoord.z == 1 and tile.tilecoord.x == 14 and tile.tilecoord.y == 11:
-                    t = MagicMock()
-                    t.data = b"dummy_png"
-                    t.content_type = "image/png"
-                    t.error = None
-                    return t
+                t = MagicMock()
+                t.data = b"dummy_png"
+                t.content_type = "image/png"
+                t.error = None
+                return t
             return None
 
-        with patch("aiohttp.ClientSession.get") as mock_get, \
-                patch("tilecloud_chain.IntersectGeometryFilter.filter_tilecoord", return_value=True), \
-                patch.object(server._TILEGENERATION, "get_store", new_callable=AsyncMock) as mock_get_store:
-
+        with (
+            patch("aiohttp.ClientSession.get") as mock_get,
+            patch("tilecloud_chain.IntersectGeometryFilter.filter_tilecoord", return_value=True),
+            patch.object(server._TILEGENERATION, "get_store", new_callable=AsyncMock) as mock_get_store,
+        ):
             # Mock the store
             mock_store = AsyncMock()
             mock_store.get_one.side_effect = get_one_side_effect
@@ -1128,7 +1128,22 @@ class TestServe(CompareCase):
             assert response.headers["Cache-Control"] == "max-age=28800"
             assert response.headers["Content-Type"] == "image/png"
 
-            # 4. GetCapabilities
+            # 4. GetTile with wrong dimensions (empty value)
+            response = client.get("/tiles/1.0.0/point_hash/default//swissgrid_5/1/11/14.png")
+            assert response.status_code == 400
+            assert response.json()["detail"] == (
+                "Wrong dimensions for layer 'point_hash': empty value(s) for dimension(s): DATE"
+            )
+
+            # 5. GetTile with wrong dimensions (extra value)
+            response = client.get("/tiles/1.0.0/point_hash/default/2012/extra/swissgrid_5/1/11/14.png")
+            assert response.status_code == 400
+            assert response.json()["detail"] == (
+                "Wrong dimensions for layer 'point_hash': expected 1 value(s) (DATE); "
+                "got 2 value(s) (2012, extra); unexpected value(s): extra"
+            )
+
+            # 6. GetCapabilities
             response = client.get("/tiles/1.0.0/WMTSCapabilities.xml")
             assert response.status_code == 200
             assert response.headers["Content-Type"] == "application/xml"


### PR DESCRIPTION
## Summary
- validate WMTS REST dimensions before mapping path segments to request params for both `GetTile` and `GetFeatureInfo`
- return `400` errors with actionable details when dimensions are missing, empty, or unexpected instead of raising an internal `IndexError`
- add REST integration assertions for malformed dimension paths and document the change in the changelog

## Testing
- pre-commit hooks executed during commit
- test execution not run in this environment (no local test runner containers/venv available)