### PR TITLE
Use nonce-based CSP for admin pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Update server, queue, admin, and generation code to read configuration from `tilecloud_chain.settings`.
 - Document the new nested environment variable scheme in `tilecloud_chain/USAGE.rst`.
 - Improve WMTS REST error messages for invalid dimensions by returning a 400 with missing, empty, unexpected, or not-allowed dimension values instead of a server error.
+- Replace `unsafe-inline` in admin CSP with c2casgiutils nonce-based CSP for inline scripts/styles.
 
 Environment variable migration (legacy -> new)
 

--- a/tilecloud_chain/main.py
+++ b/tilecloud_chain/main.py
@@ -129,20 +129,17 @@ app.add_middleware(
                     "default-src": ["'self'"],
                     "script-src-elem": [
                         "'self'",
-                        "'unsafe-inline'",  # TODO: remove this: https://github.com/camptocamp/tilecloud-chain/issues/3053
+                        headers.CSP_NONCE,
                         "https://cdnjs.cloudflare.com/ajax/libs/bootstrap/",
                         "https://cdnjs.cloudflare.com/ajax/libs/jquery/",
                         "https://cdnjs.cloudflare.com/ajax/libs/popper.js/",
                     ],
                     "style-src-elem": [
                         "'self'",
-                        "'unsafe-inline'",  # TODO: remove this: https://github.com/camptocamp/tilecloud-chain/issues/3053
+                        headers.CSP_NONCE,
                         "https://cdnjs.cloudflare.com/ajax/libs/bootstrap/",
                     ],
-                    "style-src-attr": [
-                        "'self'",
-                        "'unsafe-inline'",  # TODO: remove this: https://github.com/camptocamp/tilecloud-chain/issues/3053
-                    ],
+                    "style-src-attr": ["'none'"],
                 },
             },
         },
@@ -153,14 +150,14 @@ app.add_middleware(
                     "default-src": ["'self'"],
                     "script-src-elem": [
                         "'self'",
-                        "'unsafe-inline'",  # TODO: remove this: https://github.com/camptocamp/tilecloud-chain/issues/3053
+                        headers.CSP_NONCE,
                         "https://cdn.jsdelivr.net/npm/ol@10.8.0/",
                         "https://unpkg.com/ol-layerswitcher@4.1.2/",
                         "https://cdnjs.cloudflare.com/ajax/libs/proj4js/",
                     ],
                     "style-src-elem": [
                         "'self'",
-                        "'unsafe-inline'",  # TODO: remove this: https://github.com/camptocamp/tilecloud-chain/issues/3053
+                        headers.CSP_NONCE,
                         "https://cdn.jsdelivr.net/npm/ol@10.8.0/",
                         "https://unpkg.com/ol-layerswitcher@4.1.2/",
                     ],

--- a/tilecloud_chain/templates/admin_index.html
+++ b/tilecloud_chain/templates/admin_index.html
@@ -23,23 +23,28 @@
       crossorigin="anonymous"
       referrerpolicy="no-referrer"
     />
-    <style>
+    <style nonce="{{ nonce }}">
       a {
         text-decoration: none;
       }
       a:hover {
         text-decoration: underline;
       }
+      .auth-box {
+        position: absolute;
+        right: 3rem;
+        top: 2rem;
+      }
     </style>
   </head>
   <body class="px-5 py-4">
-    <script>
+    <script nonce="{{ nonce }}">
       /* For dark mode */
       if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
         document.documentElement.setAttribute('data-bs-theme', 'dark');
       }
     </script>
-    <div style="position: absolute; right: 3rem; top: 2rem">
+    <div class="auth-box">
       {% if not auth_info.is_logged_in and auth_type == AuthenticationType.SECRET %}
       <form>
         Secret: <input type="password" name="secret" />
@@ -59,8 +64,7 @@
       <p>
         Logged as: <a href="{{ auth_info.user.url }}">{{ auth_info.user.display_name }}</a>
         <a
-          class="btn btn-outline-primary"
-          style="vertical-align: baseline; margin-left: 0.5rem"
+          class="btn btn-outline-primary align-baseline ms-2"
           href="{{ url_for('c2c_github_logout') }}?{{ urlencode({'came_from': request.url}) }}"
           >Logout</a
         >
@@ -159,7 +163,7 @@
             aria-controls="collapse{{ nb }}"
           >
             {{ job.name }} (
-            <script>
+            <script nonce="{{ nonce }}">
               window.document.write(new Date('{{ job.created_at.isoformat() }}').toLocaleString());
             </script>
             , {{ job.status }})
@@ -201,9 +205,7 @@
               {% if 'generate' in s %}
               <!---->
               {% set comma = true %}
-              <span style="color: var(--bs-success-text-emphasis)"
-                >{{ s['generate'] }} meta tiles to generate</span
-              >
+              <span class="text-success-emphasis">{{ s['generate'] }} meta tiles to generate</span>
               {% endif %}
               <!---->
               {% if 'pending' in s %}
@@ -215,9 +217,7 @@
               {% endif %}
               <!---->
               {% set comma = true %}
-              <span style="color: var(--bs-primary-text-emphasis)"
-                >{{ s['pending'] }} meta tiles being generated</span
-              >
+              <span class="text-primary-emphasis">{{ s['pending'] }} meta tiles being generated</span>
               {% endif %}
               <!---->
               {% if 'error' in s %}
@@ -227,7 +227,7 @@
               ,
               <!---->
               {% endif %}
-              <span style="color: var(--bs-danger-text-emphasis)">{{ s['error'] }} meta tiles in error</span>
+              <span class="text-danger-emphasis">{{ s['error'] }} meta tiles in error</span>
               {% endif %}
               <br />
               {% endfor %}
@@ -328,7 +328,7 @@
       crossorigin="anonymous"
       referrerpolicy="no-referrer"
     ></script>
-    <script>
+    <script nonce="{{ nonce }}">
       $(document).ready(function () {
         $('.command').click((handler) => {
           $('#name').val(handler.target.dataset.name);

--- a/tilecloud_chain/templates/openlayers.html
+++ b/tilecloud_chain/templates/openlayers.html
@@ -37,7 +37,7 @@
       referrerpolicy="no-referrer"
       rel="stylesheet"
     />
-    <style>
+    <style nonce="{{ nonce }}">
       html,
       body,
       #map {
@@ -78,7 +78,7 @@
       referrerpolicy="no-referrer"
     ></script>
 
-    <script>
+    <script nonce="{{ nonce }}">
       proj4.defs("{{ srs }}",`{{ proj4js_def }}`);
       ol.proj.proj4.register(proj4);
       var parser = new ol.format.WMTSCapabilities();

--- a/tilecloud_chain/views/admin.py
+++ b/tilecloud_chain/views/admin.py
@@ -169,9 +169,15 @@ async def admin_index(
     if queue_store == "postgresql" and has_access and _postgresql_store and config.file:
         jobs_status = await _postgresql_store.get_status(config.file)
 
+    try:
+        nonce = request.state.nonce
+    except AttributeError as exc:
+        raise HTTPException(status_code=500, detail="CSP nonce not initialized") from exc
+
     assert auth_info, auth_info
     context = {
         "request": request,
+        "nonce": nonce,
         "has_access": has_access,
         "auth_info": auth_info,
         "auth_type": auth_type,
@@ -380,8 +386,14 @@ async def admin_test(
     if proj4js_def is None:
         proj4js_def = pyproj.CRS.from_string(srs).to_proj4()
 
+    try:
+        nonce = request.state.nonce
+    except AttributeError as exc:
+        raise HTTPException(status_code=500, detail="CSP nonce not initialized") from exc
+
     context = {
         "request": request,
+        "nonce": nonce,
         "proj4js_def": proj4js_def,
         "srs": srs,
         "center_x": config.config["openlayers"].get("center_x", configuration.CENTER_X_DEFAULT),


### PR DESCRIPTION
## Summary
- replace `unsafe-inline` in admin and admin test Content Security Policy with `c2casgiutils` nonce support (`headers.CSP_NONCE`)
- pass `request.state.nonce` to Jinja templates and add `nonce` attributes to inline `<script>` and `<style>` blocks
- remove remaining inline `style` attributes in admin template and keep CSP compatible for style attributes

Closes #3053