### PR TITLE
Enable trusted proxy header middleware wiring

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,10 @@ The environment variable should not be accessed directly (except the one defined
 The commit messages should be clear and descriptive, we don't use the conventional commits format,
 the commit message should start with a capital letter.
 
+## Pull requests
+
+The pull request description should not contain a `Testing` section.
+
 ## Bash
 
 Use the long parameter names for clarity and maintainability.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 - Document the new nested environment variable scheme in `tilecloud_chain/USAGE.rst`.
 - Improve WMTS REST error messages for invalid dimensions by returning a 400 with missing, empty, unexpected, or not-allowed dimension values instead of a server error.
 - Replace `unsafe-inline` in admin CSP with c2casgiutils nonce-based CSP for inline scripts/styles.
+- Conditionally enable `headers.ForwardedHeadersMiddleware` from `config.settings.proxy_headers` to rewrite host, scheme, and port from trusted proxy headers.
+- Document `C2C__PROXY_HEADERS__TYPE` and `C2C__PROXY_HEADERS__TRUSTED_HOSTS` for proxy header configuration.
 
 Environment variable migration (legacy -> new)
 

--- a/tilecloud_chain/main.py
+++ b/tilecloud_chain/main.py
@@ -167,6 +167,14 @@ app.add_middleware(
     },
 )
 
+proxy_headers_settings = getattr(config.settings, "proxy_headers", None)
+if proxy_headers_settings is not None and proxy_headers_settings.type != "none":
+    app.add_middleware(
+        headers.ForwardedHeadersMiddleware,
+        trusted_hosts=proxy_headers_settings.trusted_hosts,
+        headers_type=proxy_headers_settings.type,
+    )
+
 
 class RootResponse(BaseModel):
     """Response of the root endpoint."""


### PR DESCRIPTION
## Summary
- add conditional wiring for `headers.ForwardedHeadersMiddleware` in `tilecloud_chain/main.py` using `config.settings.proxy_headers`
- keep startup backward compatible by guarding access to `proxy_headers` when the runtime `c2casgiutils` version does not expose it
- document proxy header migration env vars in `CHANGELOG.md` (`C2C__PROXY_HEADERS__TYPE`, `C2C__PROXY_HEADERS__TRUSTED_HOSTS`)