### PR TITLE
Persist admin test map state in URL

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,9 @@ when you need to touch the dependencies you should update `tool.poetry.dependenc
 To develop on the project, you should use the `docker-compose.override.yaml` file.
 Copy `docker-compose.override.sample.yaml` to `docker-compose.override.yaml`.
 
+If the ports `9050`/`9051`/`9052` are in use, stop the related Docker container(s);
+otherwise the Docker container will fail to start.
+
 This will:
 
 - Mount the local source code into the container.
@@ -46,9 +49,16 @@ docker compose up -d
 
 The application will be available at:
 
-- `http://localhost:9050/` for the main application.
-- `http://localhost:9051/` for the application with a test user.
-- `http://localhost:9052/` for the application with PostgreSQL.
+- [Main application](http://localhost:9050/).
+- [Application with a test user, with Redis](http://localhost:9051/).
+- [Application with a test user, with PostgreSQL](http://localhost:9052/).
+
+Full URLs:
+
+- [Unauthenticated admin page](http://localhost:9050/tiles/admin/).
+- [Authenticated admin page with Redis](http://localhost:9051/tiles/admin/).
+- [Authenticated admin page with PostgreSQL](http://localhost:9052/tiles/admin/).
+- [Test page](http://localhost:9050/tiles/admin/test).
 
 ## Documentation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 2.0.0
 
+- Persist admin test map state in the URL on `/admin/test` with map position (`x`, `y`, `z`) and selected layer (`layer`).
 - Add a Pydantic-based settings hierarchy for environment variables.
 - Update server, queue, admin, and generation code to read configuration from `tilecloud_chain.settings`.
 - Document the new nested environment variable scheme in `tilecloud_chain/USAGE.rst`.

--- a/tilecloud_chain/USAGE.rst
+++ b/tilecloud_chain/USAGE.rst
@@ -814,3 +814,10 @@ On the URL `<base URL>/admin/` you can see the status of the generation, a tool 
 to a test page.
 
 Beware, the test page assumes we have configured only one grid.
+
+The test page stores its current state in the URL query string, so you can share or reload the same view:
+
+- ``x``: center X coordinate
+- ``y``: center Y coordinate
+- ``z``: zoom level
+- ``layer``: selected WMTS layer identifier

--- a/tilecloud_chain/templates/openlayers.html
+++ b/tilecloud_chain/templates/openlayers.html
@@ -82,6 +82,7 @@
       proj4.defs("{{ srs }}",`{{ proj4js_def }}`);
       ol.proj.proj4.register(proj4);
       var parser = new ol.format.WMTSCapabilities();
+      const requestedLayer = new URLSearchParams(window.location.search).get('layer');
 
       fetch('{{ url_for("wmts_capabilities", version="1.0.0") }}')
         .then(function (response) {
@@ -109,20 +110,36 @@
                 // To have radio buttons
                 type: 'base',
                 opacity: 1,
-                visible: visible,
+                visible: requestedLayer ? wmtsLayer.Identifier === requestedLayer : visible,
                 source: new ol.source.WMTS(options),
-                title: wmtsLayer.Title
+                title: wmtsLayer.Title,
+                name: wmtsLayer.Identifier,
               })
             );
             visible = false;
           }
+
+          if (!layers.some(function (layer) { return layer.get('type') === 'base' && layer.getVisible(); })) {
+            const firstBaseLayer = layers.find(function (layer) {
+              return layer.get('type') === 'base';
+            });
+            if (firstBaseLayer) {
+              firstBaseLayer.setVisible(true);
+            }
+          }
+
           layers.push(
             new ol.layer.Tile({
               source: new ol.source.TileDebug(tileGridOptions),
             })
           );
 
-          map = new ol.Map({
+          const defaultInteractions =
+            typeof ol.interaction.defaults === 'function'
+              ? ol.interaction.defaults()
+              : ol.interaction.defaults.defaults();
+
+          const map = new ol.Map({
             layers: layers,
             target: 'map',
             view: new ol.View({
@@ -132,7 +149,35 @@
               resolutions: resolutions,
               constrainResolution: true
             }),
+            interactions: defaultInteractions.extend([
+              new ol.interaction.Link({
+                params: ['x', 'y', 'z'],
+                replace: true,
+              }),
+            ]),
           });
+
+          const updateLayerInUrl = function () {
+            const activeBaseLayer = map
+              .getLayers()
+              .getArray()
+              .find(function (layer) {
+                return layer.get('type') === 'base' && layer.getVisible();
+              });
+            const url = new URL(window.location.href);
+            if (activeBaseLayer) {
+              url.searchParams.set('layer', activeBaseLayer.get('name'));
+            } else {
+              url.searchParams.delete('layer');
+            }
+            window.history.replaceState(history.state, '', url);
+          };
+
+          map.getLayerGroup().on('change', function () {
+            updateLayerInUrl();
+          });
+
+          updateLayerInUrl();
 
           const layerSwitcher = new ol.control.LayerSwitcher({
             activationMode: 'click',


### PR DESCRIPTION
## Summary
- add OpenLayers `ol.interaction.Link` on the `/admin/test` map to persist map state in the URL query string
- document the URL parameters used by the admin test page in `tilecloud_chain/USAGE.rst`
- add a changelog entry for the new URL state behavior on the test page