### PR TITLE
Fix PostgreSQL queue cleanup when child tiles fail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Replace `unsafe-inline` in admin CSP with c2casgiutils nonce-based CSP for inline scripts/styles.
 - Conditionally enable `headers.ForwardedHeadersMiddleware` from `config.settings.proxy_headers` to rewrite host, scheme, and port from trusted proxy headers.
 - Document `C2C__PROXY_HEADERS__TYPE` and `C2C__PROXY_HEADERS__TRUSTED_HOSTS` for proxy header configuration.
+- Fix PostgreSQL queue cleanup on generation errors so child tiles release their parent metatile queue item instead of failing with missing `postgresql_id`.
 
 Environment variable migration (legacy -> new)
 

--- a/tilecloud_chain/__init__.py
+++ b/tilecloud_chain/__init__.py
@@ -339,7 +339,13 @@ class Run:
                         self.max_consecutive_errors(tile)
 
                     if self.gene.queue_store is not None:
-                        await self.gene.queue_store.delete_one(tile)
+                        if hasattr(tile, "metatile"):
+                            metatile: Tile = tile.metatile
+                            metatile.elapsed_togenerate -= 1  # type: ignore[attr-defined]
+                            if metatile.elapsed_togenerate == 0:  # type: ignore[attr-defined]
+                                await self.gene.queue_store.delete_one(metatile)
+                        else:
+                            await self.gene.queue_store.delete_one(tile)
                     async with self.error_lock:
                         self.error += 1
                     return tile

--- a/tilecloud_chain/tests/test_error.py
+++ b/tilecloud_chain/tests/test_error.py
@@ -1,11 +1,17 @@
 import os
 from pathlib import Path
+from types import SimpleNamespace
+from typing import TYPE_CHECKING, cast
 
 import pytest
 from testfixtures import LogCapture
+from tilecloud import Tile, TileCoord
 
-from tilecloud_chain import controller, generate
+from tilecloud_chain import Run, controller, generate
 from tilecloud_chain.tests import CompareCase
+
+if TYPE_CHECKING:
+    from tilecloud_chain import TileGeneration
 
 
 class TestError(CompareCase):
@@ -228,3 +234,88 @@ class TestError(CompareCase):
 -- tilegeneration/wrong_sequence.yaml:3:5 grids.test: 'srs' is a required property (rule: properties.grids.additionalProperties.required)""",
                 ),
             )
+
+
+@pytest.mark.asyncio
+async def test_run_delete_metatile_on_error() -> None:
+    class QueueStore:
+        def __init__(self) -> None:
+            self.deleted: list[Tile] = []
+
+        async def delete_one(self, tile: Tile) -> Tile:
+            self.deleted.append(tile)
+            return tile
+
+    queue_store = QueueStore()
+
+    class DummyGeneration:
+        def __init__(self, queue_store: QueueStore) -> None:
+            self.queue_store = queue_store
+            self.options = SimpleNamespace(debug=False)
+            self.maxconsecutive_errors = False
+
+        async def get_main_config(self):
+            return SimpleNamespace(config={"generation": {}})
+
+    async def identity(tile: Tile) -> Tile:
+        return tile
+
+    run = Run(cast("TileGeneration", DummyGeneration(queue_store)), [identity])
+    run.max_consecutive_errors = None
+
+    metatile = Tile(TileCoord(2, 2, 1))
+    metatile.postgresql_id = 42
+    metatile.elapsed_togenerate = 1
+
+    child_tile = Tile(
+        TileCoord(2, 2, 1),
+        metadata={
+            "config_file": "/etc/tilegeneration/config.yaml",
+            "dimension_DATE": "20230811",
+            "grid": "3857",
+            "host": "localhost",
+            "job_id": 3,
+            "layer": "osm-wmts",
+        },
+    )
+    child_tile.metatile = metatile
+    child_tile.error = "boom"
+
+    await run(child_tile)
+
+    assert queue_store.deleted == [metatile]
+
+
+@pytest.mark.asyncio
+async def test_run_delete_tile_on_error_without_metatile() -> None:
+    class QueueStore:
+        def __init__(self) -> None:
+            self.deleted: list[Tile] = []
+
+        async def delete_one(self, tile: Tile) -> Tile:
+            self.deleted.append(tile)
+            return tile
+
+    queue_store = QueueStore()
+
+    class DummyGeneration:
+        def __init__(self, queue_store: QueueStore) -> None:
+            self.queue_store = queue_store
+            self.options = SimpleNamespace(debug=False)
+            self.maxconsecutive_errors = False
+
+        async def get_main_config(self):
+            return SimpleNamespace(config={"generation": {}})
+
+    async def identity(tile: Tile) -> Tile:
+        return tile
+
+    run = Run(cast("TileGeneration", DummyGeneration(queue_store)), [identity])
+    run.max_consecutive_errors = None
+
+    tile = Tile(TileCoord(2, 2, 1), metadata={"layer": "osm-wmts", "host": "localhost"})
+    tile.error = "boom"
+
+    await run(tile)
+
+    assert queue_store.deleted == [tile]


### PR DESCRIPTION
## Summary
- Fix generic error handling in `Run` to release the queue entry through the parent metatile when a child tile fails.
- Keep the existing fallback behavior for tiles without a parent metatile.
- Add regression tests for both code paths and document the user-visible fix in the changelog.