### PR TITLE
Highlight running jobs in green in admin

### DIFF
--- a/tilecloud_chain/templates/admin_index.html
+++ b/tilecloud_chain/templates/admin_index.html
@@ -166,7 +166,11 @@
             <script nonce="{{ nonce }}">
               window.document.write(new Date('{{ job.created_at.isoformat() }}').toLocaleString());
             </script>
-            , {{ job.status }})
+            ,
+            <span
+              class="badge {% if job.status == 'started' %}text-bg-success{% elif job.status == 'error' %}text-bg-danger{% elif job.status == 'done' %}text-bg-primary{% elif job.status == 'cancelled' %}text-bg-secondary{% else %}text-bg-light text-dark{% endif %}"
+              >{{ job.status }}</span
+            >)
             <!-- {{ job.id }} -->
           </button>
         </h2>


### PR DESCRIPTION
## Summary
- Display job status as Bootstrap badges in the admin jobs accordion for better readability.
- Highlight the `started` status with a green badge so the running job is clearly visible.
- Keep distinct colors for other statuses (`error`, `done`, `cancelled`, fallback) for quick scanning.