### PR TITLE
Fix WMTS InfoFormat rendering for OpenLayers GetFeatureInfo example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Fix PostgreSQL queue cleanup on generation errors so child tiles release their parent metatile queue item instead of failing with missing `postgresql_id`.
 - In `/tiles/admin/test` add layer dimension selectors.
 - Batch PostgreSQL queue inserts (default 10,000 rows) for large metatile pyramids and add `TILECLOUD_CHAIN__POSTGRESQL__QUEUE_INSERT_BATCH_SIZE` to configure batch size.
+- Use WMTS GetFeatureInfo in the `/admin/test` OpenLayers page by querying the active layer on map click and showing the response in a feature info panel.
 
 Environment variable migration (legacy -> new)
 

--- a/tilecloud_chain/USAGE.rst
+++ b/tilecloud_chain/USAGE.rst
@@ -841,3 +841,6 @@ The test page stores its current state in the URL query string, so you can share
 - ``y``: center Y coordinate
 - ``z``: zoom level
 - ``layer``: selected WMTS layer identifier
+
+In the test page, clicking on the map sends a WMTS GetFeatureInfo request on the active layer (if queryable)
+and displays the response in a "Feature info" panel.

--- a/tilecloud_chain/templates/openlayers.html
+++ b/tilecloud_chain/templates/openlayers.html
@@ -56,6 +56,32 @@
         font-size: 0.95em;
       }
 
+      .feature-info-panel {
+        left: 0.5em;
+        bottom: 0.5em;
+        max-height: min(18em, calc(100% - 1em));
+        max-width: min(36em, calc(100% - 1em));
+        overflow: auto;
+        background-color: rgba(255, 255, 255, 0.95);
+        color: #111;
+        border-radius: 0.35em;
+        box-shadow: 0 1px 4px rgba(0, 0, 0, 0.35);
+        padding: 0.75em;
+        font-size: 0.85em;
+        display: none;
+      }
+
+      .feature-info-panel-title {
+        margin: 0 0 0.5em;
+        font-weight: 600;
+      }
+
+      .feature-info-panel-content {
+        margin: 0;
+        white-space: pre-wrap;
+        word-break: break-word;
+      }
+
       .layer-panel-title {
         margin: 0 0 0.5em;
         font-weight: 600;
@@ -135,6 +161,12 @@
 
         .layer-panel-item {
           border-top-color: rgba(255, 255, 255, 0.2);
+        }
+
+        .feature-info-panel {
+          background-color: rgba(42, 42, 42, 0.95);
+          color: #f2f2f2;
+          border: 1px solid rgba(255, 255, 255, 0.2);
         }
       }
     </style>
@@ -223,6 +255,16 @@
         return dimensions;
       };
 
+      const getLayerInfoFormats = function (wmtsLayer) {
+        if (!wmtsLayer.InfoFormat) {
+          return [];
+        }
+        if (Array.isArray(wmtsLayer.InfoFormat)) {
+          return wmtsLayer.InfoFormat;
+        }
+        return [wmtsLayer.InfoFormat];
+      };
+
       const getLayerGridDefinitions = function (result, wmtsLayer) {
         const links = wmtsLayer.TileMatrixSetLink || [];
         const definitions = links
@@ -306,6 +348,7 @@
             const options = selectedGridDefinition.wmtsOptions;
             const layerDefaultDimensions = getLayerDefaultDimensions(wmtsLayer);
             const layerDimensionDefinitions = getLayerDimensionDefinitions(wmtsLayer);
+            const layerInfoFormats = getLayerInfoFormats(wmtsLayer);
             const sourceDimensions = {
               ...layerDefaultDimensions,
               ...(options.dimensions || {}),
@@ -326,6 +369,7 @@
                 title: wmtsLayer.Title,
                 name: wmtsLayer.Identifier,
                 dimensionDefinitions: layerDimensionDefinitions,
+                infoFormats: layerInfoFormats,
                 gridDefinitions: gridDefinitions,
                 selectedGridId: selectedGridDefinition.id,
               })
@@ -784,6 +828,102 @@
           const panel = createPanelControl();
           map.addControl(panel.control);
           panel.render();
+
+          const createFeatureInfoControl = function () {
+            const element = document.createElement('div');
+            element.className = 'feature-info-panel ol-unselectable ol-control';
+
+            const title = document.createElement('h3');
+            title.className = 'feature-info-panel-title';
+            title.textContent = 'Feature info';
+            element.appendChild(title);
+
+            const content = document.createElement('pre');
+            content.className = 'feature-info-panel-content';
+            content.textContent = 'Click on the map to run WMTS GetFeatureInfo.';
+            element.appendChild(content);
+
+            return {
+              control: new ol.control.Control({ element: element }),
+              setContent: function (nextContent) {
+                content.textContent = nextContent;
+                element.style.display = 'block';
+              },
+            };
+          };
+
+          const featureInfo = createFeatureInfoControl();
+          map.addControl(featureInfo.control);
+
+          map.on('singleclick', function (event) {
+            const activeBaseLayer = getActiveBaseLayer();
+            if (!activeBaseLayer) {
+              featureInfo.setContent('No active layer.');
+              return;
+            }
+
+            const source = activeBaseLayer.getSource();
+            if (!source || typeof source.getFeatureInfoUrl !== 'function') {
+              featureInfo.setContent('The active layer does not support WMTS GetFeatureInfo.');
+              return;
+            }
+
+            const infoFormats = activeBaseLayer.get('infoFormats') || [];
+            if (infoFormats.length === 0) {
+              featureInfo.setContent('The active layer is not queryable.');
+              return;
+            }
+
+            const view = map.getView();
+            const resolution = view.getResolution();
+            const projection = view.getProjection();
+            const infoFormat = infoFormats[0];
+            if (resolution === undefined || !projection) {
+              featureInfo.setContent('Cannot compute a valid GetFeatureInfo request for this view.');
+              return;
+            }
+
+            const url = source.getFeatureInfoUrl(event.coordinate, resolution, projection, {
+              'INFO_FORMAT': infoFormat,
+            });
+            if (!url) {
+              featureInfo.setContent('Cannot build the WMTS GetFeatureInfo URL for this layer.');
+              return;
+            }
+
+            featureInfo.setContent('Loading WMTS GetFeatureInfo...');
+            fetch(url)
+              .then(function (response) {
+                return response.text().then(function (text) {
+                  return {
+                    ok: response.ok,
+                    status: response.status,
+                    contentType: response.headers.get('Content-Type') || '',
+                    body: text,
+                  };
+                });
+              })
+              .then(function (result) {
+                const statusLine = 'Status: ' + result.status + (result.ok ? '' : ' (error)');
+                const formatLine = 'InfoFormat: ' + infoFormat;
+                const contentTypeLine = 'Content-Type: ' + (result.contentType || 'unknown');
+                const requestLine = 'Request URL: ' + url;
+                featureInfo.setContent(
+                  statusLine +
+                  '\n' +
+                  formatLine +
+                  '\n' +
+                  contentTypeLine +
+                  '\n' +
+                  requestLine +
+                  '\n\n' +
+                  result.body
+                );
+              })
+              .catch(function (error) {
+                featureInfo.setContent('GetFeatureInfo request failed: ' + error);
+              });
+          });
 
           updateLayerInUrl();
         });

--- a/tilecloud_chain/templates/wmts_get_capabilities.jinja
+++ b/tilecloud_chain/templates/wmts_get_capabilities.jinja
@@ -150,7 +150,7 @@
       <Format>{{ layer['mime_type'] }}</Format>{%
       if 'query_layers' in layer %}{%
       for info_format in layer.get('info_formats', ['application/vnd.ogc.gml']) %}
-      <InfoFormat>{{ infoformat }}</InfoFormat>{%
+      <InfoFormat>{{ info_format }}</InfoFormat>{%
       endfor %}{%
       endif %}{%
       for dimension in layer['dimensions'] %}

--- a/tilecloud_chain/tests/test_serve.py
+++ b/tilecloud_chain/tests/test_serve.py
@@ -67,7 +67,7 @@ _CAPABILITIES = (
         <ows:Identifier>default</ows:Identifier>
       </Style>
       <Format>image/png</Format>
-      <InfoFormat></InfoFormat>
+      <InfoFormat>application/vnd.ogc.gml</InfoFormat>
       <Dimension>
         <ows:Identifier>DATE</ows:Identifier>
         <Default>2012</Default>

--- a/tilecloud_chain/tests/test_ui.py
+++ b/tilecloud_chain/tests/test_ui.py
@@ -74,3 +74,14 @@ def test_openlayers_grid_selector_handles_projection_change():
     assert "transformedExtent = transformExtentSafe(" in content
     assert "nextView.fit(transformedExtent," in content
     assert "transformCenterSafe(currentCenter, currentProjectionCode, nextProjectionCode)" in content
+
+
+def test_openlayers_test_page_uses_wmts_getfeatureinfo_on_click():
+    content = (Path(__file__).parent.parent / "templates" / "openlayers.html").read_text()
+
+    assert "map.on('singleclick', function (event) {" in content
+    assert "source.getFeatureInfoUrl(event.coordinate, resolution, projection, {" in content
+    assert "'INFO_FORMAT': infoFormat," in content
+    assert "fetch(url)" in content
+    assert "Feature info" in content
+    assert "Request URL: " in content


### PR DESCRIPTION
## Summary
- fix the WMTS capabilities template to render the correct `InfoFormat` value from `info_format` instead of an undefined variable
- restore a valid `InfoFormat` (`application/vnd.ogc.gml`) in capabilities responses for queryable layers
- update the capabilities test expectation to cover the corrected output and prevent regressions

Closes #162