### PR TITLE
Enable tile optimization in example configurations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 - In `/tiles/admin/test` add layer dimension selectors.
 - Batch PostgreSQL queue inserts (default 10,000 rows) for large metatile pyramids and add `TILECLOUD_CHAIN__POSTGRESQL__QUEUE_INSERT_BATCH_SIZE` to configure batch size.
 - Use WMTS GetFeatureInfo in the `/admin/test` OpenLayers page by querying the active layer on map click and showing the response in a feature info panel.
+- Update example tilegeneration configs to enable tile optimization (`post_process` with `optipng`/`jpegoptim` and Pillow `meta_save_options`).
+- Document how to combine `post_process` and `meta_save_options` to optimize PNG/JPEG tiles.
 
 Environment variable migration (legacy -> new)
 

--- a/example/tilegeneration/config-postgresql.yaml
+++ b/example/tilegeneration/config-postgresql.yaml
@@ -88,11 +88,18 @@ layers:
   plan:
     <<: *layer
     layers: line
+    post_process: optipng
+    meta_save_options:
+      optimize: true
   ortho:
     <<: *layer
     layers: point
     extension: jpeg
     mime_type: image/jpeg
+    post_process: jpegoptim
+    meta_save_options:
+      optimize: true
+      quality: 90
     # no buffer needed on rater sources
     meta_buffer: 0
     empty_metatile_detection:

--- a/example/tilegeneration/config.yaml
+++ b/example/tilegeneration/config.yaml
@@ -83,11 +83,18 @@ layers:
   plan:
     <<: *layer
     layers: plan
+    post_process: optipng
+    meta_save_options:
+      optimize: true
   ortho:
     <<: *layer
     layers: ortho
     extension: jpeg
     mime_type: image/jpeg
+    post_process: jpegoptim
+    meta_save_options:
+      optimize: true
+      quality: 90
     # no buffer needed on rater sources
     meta_buffer: 0
     empty_metatile_detection:

--- a/tilecloud_chain/USAGE.rst
+++ b/tilecloud_chain/USAGE.rst
@@ -302,6 +302,26 @@ The ``cmd`` can have the following optional argument:
 -  ``in``, ``out`` the input and output files.
 -  ``x``, ``y``, ``z`` the tile coordinates.
 
+To optimize output images, configure both:
+
+- ``post_process`` on each layer to run external tools (for example ``optipng`` or ``jpegoptim``), and
+- ``meta_save_options`` on each layer to pass Pillow save options when splitting meta-tiles.
+
+Example:
+
+.. code:: yaml
+
+    layers:
+      plan:
+        post_process: optipng
+        meta_save_options:
+          optimize: true
+      ortho:
+        post_process: jpegoptim
+        meta_save_options:
+          optimize: true
+          quality: 90
+
 Logging
 ~~~~~~~
 


### PR DESCRIPTION
## Summary
- enable tile optimization in example layer configs by setting `post_process` to `optipng` for PNG and `jpegoptim` for JPEG
- add Pillow `meta_save_options` in examples (`optimize: true`, plus `quality: 90` for JPEG) so meta-tile split output is optimized too
- document the recommended combination of `post_process` and `meta_save_options` in the usage guide and record it in the changelog

Closes #8