### PR TITLE
Report consumed queue jobs in slave output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Use WMTS GetFeatureInfo in the `/admin/test` OpenLayers page by querying the active layer on map click and showing the response in a feature info panel.
 - Update example tilegeneration configs to enable tile optimization (`post_process` with `optipng`/`jpegoptim` and Pillow `meta_save_options`).
 - Document how to combine `post_process` and `meta_save_options` to optimize PNG/JPEG tiles.
+- Add `Nb of consumed jobs` to slave generation output to report how many queue jobs were consumed, complementing the master's generated jobs count.
 
 Environment variable migration (legacy -> new)
 

--- a/tilecloud_chain/USAGE.rst
+++ b/tilecloud_chain/USAGE.rst
@@ -477,11 +477,15 @@ To use the SQS queue we should first fill the queue:
 
     generate-tiles --role master --layer <a_layer>
 
+The command output includes ``Nb of generated jobs: N`` to show how many jobs were inserted in the queue.
+
 And then generate the tiles present in the SQS queue:
 
 .. prompt:: bash
 
     generate-tiles --role slave --layer <a_layer>
+
+The command output includes ``Nb of consumed jobs: N`` to show how many jobs were consumed from the queue.
 
 For the slave to keep listening when the queue is empty and be able to support more than one layer, you must
 enable the daemon mode and must not specify the layer:

--- a/tilecloud_chain/generate.py
+++ b/tilecloud_chain/generate.py
@@ -419,11 +419,11 @@ class Generate:
             if self._options.role == "master":
                 assert self._count_tiles
                 message.append(f"Nb of generated jobs: {self._count_tiles.nb}")
-            elif self._options.role == "slave":
+            if self._options.role == "slave" and not self._options.tiles:
                 assert self._count_meta_tiles is not None
                 message.append(f"Nb of consumed jobs: {self._count_meta_tiles.nb}")
 
-            elif layer.get("meta") if layer is not None else self._options.role == "slave":
+            if layer.get("meta") if layer is not None else self._options.role == "slave":
                 assert self._count_meta_tiles is not None
                 assert self._count_metatiles_dropped is not None
                 message += [

--- a/tilecloud_chain/generate.py
+++ b/tilecloud_chain/generate.py
@@ -419,6 +419,10 @@ class Generate:
             if self._options.role == "master":
                 assert self._count_tiles
                 message.append(f"Nb of generated jobs: {self._count_tiles.nb}")
+            elif self._options.role == "slave":
+                assert self._count_meta_tiles is not None
+                message.append(f"Nb of consumed jobs: {self._count_meta_tiles.nb}")
+
             elif layer.get("meta") if layer is not None else self._options.role == "slave":
                 assert self._count_meta_tiles is not None
                 assert self._count_metatiles_dropped is not None

--- a/tilecloud_chain/tests/test_generate.py
+++ b/tilecloud_chain/tests/test_generate.py
@@ -1123,6 +1123,7 @@ Tiles in error:
             main_func=generate.async_main,
             regex=True,
             expected=r"""The tile generation is finish
+Nb of consumed jobs: 10
 Nb generated metatiles: 10
 Nb metatiles dropped: 0
 Nb generated tiles: 640
@@ -1179,6 +1180,7 @@ Tiles in error:
                 main_func=generate.async_main,
                 regex=True,
                 expected=r"""The tile generation is finish
+    Nb of consumed jobs: 10
     Nb generated metatiles: 10
     Nb metatiles dropped: 0
     Nb generated tiles: 640


### PR DESCRIPTION
## Summary
- add a slave-side summary line (`Nb of consumed jobs`) in `generate-tiles` to report how many queue jobs were consumed
- keep master output unchanged (`Nb of generated jobs`) so both queue insertion and consumption are visible
- update Redis generation tests, user documentation, and changelog entry for the new output