### PR TITLE
Add WMTS TileMatrixSetLimits in capabilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Use WMTS GetFeatureInfo in the `/admin/test` OpenLayers page by querying the active layer on map click and showing the response in a feature info panel.
 - Update example tilegeneration configs to enable tile optimization (`post_process` with `optipng`/`jpegoptim` and Pillow `meta_save_options`).
 - Document how to combine `post_process` and `meta_save_options` to optimize PNG/JPEG tiles.
+- Add `TileMatrixSetLimits` entries in WMTS capabilities when a layer defines a `bbox`, so clients can restrict tile requests to the advertised extent.
 
 Environment variable migration (legacy -> new)
 

--- a/tilecloud_chain/USAGE.rst
+++ b/tilecloud_chain/USAGE.rst
@@ -78,6 +78,9 @@ To start the common attributes are:
 
 ``bbox`` used to limit the tiles generation.
 
+When generating WMTS capabilities, if a layer ``bbox`` is defined, it is also used to publish
+``TileMatrixSetLimits`` in each ``TileMatrixSetLink`` for that layer.
+
 ``px_buffer`` a buffer in px around the object area (geoms or extent).
 
 WMTS layout

--- a/tilecloud_chain/__init__.py
+++ b/tilecloud_chain/__init__.py
@@ -537,6 +537,57 @@ def get_grid_names(
     return grid_names
 
 
+def get_tile_matrix_limits(
+    config: DatedConfig,
+    layer_name: str,
+    grid_name: str,
+) -> list[dict[str, int | str]]:
+    """Get WMTS tile matrix limits for a layer and grid."""
+    layer = config.config["layers"][layer_name]
+    if "bbox" not in layer:
+        return []
+
+    grid = config.config["grids"][grid_name]
+    layer_bbox = [float(value) for value in layer["bbox"]]
+    if (
+        "proj4_literal" in layer
+        and "proj4_literal" in grid
+        and layer["proj4_literal"] != grid["proj4_literal"]
+    ):
+        layer_bbox = transform_bbox(layer["proj4_literal"], grid["proj4_literal"], layer_bbox)
+
+    grid_bbox = [float(value) for value in grid["bbox"]]
+    min_x = max(layer_bbox[0], grid_bbox[0])
+    min_y = max(layer_bbox[1], grid_bbox[1])
+    max_x = min(layer_bbox[2], grid_bbox[2])
+    max_y = min(layer_bbox[3], grid_bbox[3])
+    if min_x >= max_x or min_y >= max_y:
+        return []
+
+    tile_size = float(grid.get("tile_size", configuration.TILE_SIZE_DEFAULT))
+    limits: list[dict[str, int | str]] = []
+    for zoom, resolution in enumerate(grid["resolutions"]):
+        tile_span = float(resolution) * tile_size
+        matrix_width = math.ceil((grid_bbox[2] - grid_bbox[0]) / tile_span)
+        matrix_height = math.ceil((grid_bbox[3] - grid_bbox[1]) / tile_span)
+
+        min_tile_col = math.floor((min_x - grid_bbox[0]) / tile_span)
+        max_tile_col = math.ceil((max_x - grid_bbox[0]) / tile_span) - 1
+        min_tile_row = math.floor((grid_bbox[3] - max_y) / tile_span)
+        max_tile_row = math.ceil((grid_bbox[3] - min_y) / tile_span) - 1
+
+        limits.append(
+            {
+                "tile_matrix": get_tile_matrix_identifier(grid, resolution=float(resolution), zoom=zoom),
+                "min_tile_row": max(0, min(matrix_height - 1, min_tile_row)),
+                "max_tile_row": max(0, min(matrix_height - 1, max_tile_row)),
+                "min_tile_col": max(0, min(matrix_width - 1, min_tile_col)),
+                "max_tile_col": max(0, min(matrix_width - 1, max_tile_col)),
+            },
+        )
+    return limits
+
+
 def get_proj4_literal(srs: int) -> str:
     """Get the proj4 literal for a given SRS."""
     # Map known SRS values to their proj4 literals

--- a/tilecloud_chain/server.py
+++ b/tilecloud_chain/server.py
@@ -522,6 +522,7 @@ class Server:
                         "has_provider": "provider" in config.config,
                         "provider": config.config.get("provider"),
                         "get_grid_names": tilecloud_chain.get_grid_names,
+                        "get_tile_matrix_limits": tilecloud_chain.get_tile_matrix_limits,
                         "enumerate": enumerate,
                         "ceil": math.ceil,
                         "int": int,

--- a/tilecloud_chain/templates/wmts_get_capabilities.jinja
+++ b/tilecloud_chain/templates/wmts_get_capabilities.jinja
@@ -169,12 +169,22 @@
                             %}/{{ ('{' + dimension['name'] + '}') }}{%
                         endfor
                    %}/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.{{ layer['extension'] }}" />{%
-      endfor %}{%
-        for grid_name in get_grid_names(config, layer_name) %}
+       endfor %}{%
+         for grid_name in get_grid_names(config, layer_name) %}
       <TileMatrixSetLink>
-        <TileMatrixSet>{{ grid_name }}</TileMatrixSet>
+        <TileMatrixSet>{{ grid_name }}</TileMatrixSet>{% set tile_matrix_limits = get_tile_matrix_limits(config, layer_name, grid_name) %}{%
+        if tile_matrix_limits %}
+        <TileMatrixSetLimits>{% for limit in tile_matrix_limits %}
+          <TileMatrixLimits>
+            <TileMatrix>{{ limit['tile_matrix'] }}</TileMatrix>
+            <MinTileRow>{{ limit['min_tile_row'] }}</MinTileRow>
+            <MaxTileRow>{{ limit['max_tile_row'] }}</MaxTileRow>
+            <MinTileCol>{{ limit['min_tile_col'] }}</MinTileCol>
+            <MaxTileCol>{{ limit['max_tile_col'] }}</MaxTileCol>
+          </TileMatrixLimits>{% endfor %}
+        </TileMatrixSetLimits>{% endif %}
       </TileMatrixSetLink>{%
-        endfor %}
+         endfor %}
     </Layer>
     {% endfor %}
 

--- a/tilecloud_chain/tests/test_controller.py
+++ b/tilecloud_chain/tests/test_controller.py
@@ -164,6 +164,43 @@ class TestController(CompareCase):
             """{DATE}/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.png" />
       <TileMatrixSetLink>
         <TileMatrixSet>swissgrid_5</TileMatrixSet>
+        <TileMatrixSetLimits>
+          <TileMatrixLimits>
+            <TileMatrix>0</TileMatrix>
+            <MinTileRow>6</MinTileRow>
+            <MaxTileRow>7</MaxTileRow>
+            <MinTileCol>5</MinTileCol>
+            <MaxTileCol>5</MaxTileCol>
+          </TileMatrixLimits>
+          <TileMatrixLimits>
+            <TileMatrix>1</TileMatrix>
+            <MinTileRow>13</MinTileRow>
+            <MaxTileRow>14</MaxTileRow>
+            <MinTileCol>10</MinTileCol>
+            <MaxTileCol>10</MaxTileCol>
+          </TileMatrixLimits>
+          <TileMatrixLimits>
+            <TileMatrix>2</TileMatrix>
+            <MinTileRow>33</MinTileRow>
+            <MaxTileRow>35</MaxTileRow>
+            <MinTileCol>25</MinTileCol>
+            <MaxTileCol>27</MaxTileCol>
+          </TileMatrixLimits>
+          <TileMatrixLimits>
+            <TileMatrix>3</TileMatrix>
+            <MinTileRow>66</MinTileRow>
+            <MaxTileRow>70</MaxTileRow>
+            <MinTileCol>50</MinTileCol>
+            <MaxTileCol>54</MaxTileCol>
+          </TileMatrixLimits>
+          <TileMatrixLimits>
+            <TileMatrix>4</TileMatrix>
+            <MinTileRow>132</MinTileRow>
+            <MaxTileRow>140</MaxTileRow>
+            <MinTileCol>101</MinTileCol>
+            <MaxTileCol>109</MaxTileCol>
+          </TileMatrixLimits>
+        </TileMatrixSetLimits>
       </TileMatrixSetLink>
     </Layer>
 
@@ -613,6 +650,43 @@ class TestController(CompareCase):
         r"""{DATE}/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.png" />
       <TileMatrixSetLink>
         <TileMatrixSet>swissgrid_5</TileMatrixSet>
+        <TileMatrixSetLimits>
+          <TileMatrixLimits>
+            <TileMatrix>0</TileMatrix>
+            <MinTileRow>6</MinTileRow>
+            <MaxTileRow>7</MaxTileRow>
+            <MinTileCol>5</MinTileCol>
+            <MaxTileCol>5</MaxTileCol>
+          </TileMatrixLimits>
+          <TileMatrixLimits>
+            <TileMatrix>1</TileMatrix>
+            <MinTileRow>13</MinTileRow>
+            <MaxTileRow>14</MaxTileRow>
+            <MinTileCol>10</MinTileCol>
+            <MaxTileCol>10</MaxTileCol>
+          </TileMatrixLimits>
+          <TileMatrixLimits>
+            <TileMatrix>2</TileMatrix>
+            <MinTileRow>33</MinTileRow>
+            <MaxTileRow>35</MaxTileRow>
+            <MinTileCol>25</MinTileCol>
+            <MaxTileCol>27</MaxTileCol>
+          </TileMatrixLimits>
+          <TileMatrixLimits>
+            <TileMatrix>3</TileMatrix>
+            <MinTileRow>66</MinTileRow>
+            <MaxTileRow>70</MaxTileRow>
+            <MinTileCol>50</MinTileCol>
+            <MaxTileCol>54</MaxTileCol>
+          </TileMatrixLimits>
+          <TileMatrixLimits>
+            <TileMatrix>4</TileMatrix>
+            <MinTileRow>132</MinTileRow>
+            <MaxTileRow>140</MaxTileRow>
+            <MinTileCol>101</MinTileCol>
+            <MaxTileCol>109</MaxTileCol>
+          </TileMatrixLimits>
+        </TileMatrixSetLimits>
       </TileMatrixSetLink>
     </Layer>
 
@@ -1920,6 +1994,43 @@ sqs:
             r"""{DATE}/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.png" />
       <TileMatrixSetLink>
         <TileMatrixSet>swissgrid</TileMatrixSet>
+        <TileMatrixSetLimits>
+          <TileMatrixLimits>
+            <TileMatrix>0</TileMatrix>
+            <MinTileRow>6</MinTileRow>
+            <MaxTileRow>7</MaxTileRow>
+            <MinTileCol>5</MinTileCol>
+            <MaxTileCol>5</MaxTileCol>
+          </TileMatrixLimits>
+          <TileMatrixLimits>
+            <TileMatrix>1</TileMatrix>
+            <MinTileRow>13</MinTileRow>
+            <MaxTileRow>14</MaxTileRow>
+            <MinTileCol>10</MinTileCol>
+            <MaxTileCol>10</MaxTileCol>
+          </TileMatrixLimits>
+          <TileMatrixLimits>
+            <TileMatrix>2</TileMatrix>
+            <MinTileRow>33</MinTileRow>
+            <MaxTileRow>35</MaxTileRow>
+            <MinTileCol>25</MinTileCol>
+            <MaxTileCol>27</MaxTileCol>
+          </TileMatrixLimits>
+          <TileMatrixLimits>
+            <TileMatrix>3</TileMatrix>
+            <MinTileRow>66</MinTileRow>
+            <MaxTileRow>70</MaxTileRow>
+            <MinTileCol>50</MinTileCol>
+            <MaxTileCol>54</MaxTileCol>
+          </TileMatrixLimits>
+          <TileMatrixLimits>
+            <TileMatrix>4</TileMatrix>
+            <MinTileRow>132</MinTileRow>
+            <MaxTileRow>140</MaxTileRow>
+            <MinTileCol>101</MinTileCol>
+            <MaxTileCol>109</MaxTileCol>
+          </TileMatrixLimits>
+        </TileMatrixSetLimits>
       </TileMatrixSetLink>
     </Layer>
 
@@ -2126,6 +2237,43 @@ sqs:
             r"""{DATE}/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.png" />
       <TileMatrixSetLink>
         <TileMatrixSet>swissgrid</TileMatrixSet>
+        <TileMatrixSetLimits>
+          <TileMatrixLimits>
+            <TileMatrix>0</TileMatrix>
+            <MinTileRow>6</MinTileRow>
+            <MaxTileRow>7</MaxTileRow>
+            <MinTileCol>5</MinTileCol>
+            <MaxTileCol>5</MaxTileCol>
+          </TileMatrixLimits>
+          <TileMatrixLimits>
+            <TileMatrix>1</TileMatrix>
+            <MinTileRow>13</MinTileRow>
+            <MaxTileRow>14</MaxTileRow>
+            <MinTileCol>10</MinTileCol>
+            <MaxTileCol>10</MaxTileCol>
+          </TileMatrixLimits>
+          <TileMatrixLimits>
+            <TileMatrix>2</TileMatrix>
+            <MinTileRow>33</MinTileRow>
+            <MaxTileRow>35</MaxTileRow>
+            <MinTileCol>25</MinTileCol>
+            <MaxTileCol>27</MaxTileCol>
+          </TileMatrixLimits>
+          <TileMatrixLimits>
+            <TileMatrix>3</TileMatrix>
+            <MinTileRow>66</MinTileRow>
+            <MaxTileRow>70</MaxTileRow>
+            <MinTileCol>50</MinTileCol>
+            <MaxTileCol>54</MaxTileCol>
+          </TileMatrixLimits>
+          <TileMatrixLimits>
+            <TileMatrix>4</TileMatrix>
+            <MinTileRow>132</MinTileRow>
+            <MaxTileRow>140</MaxTileRow>
+            <MinTileCol>101</MinTileCol>
+            <MaxTileCol>109</MaxTileCol>
+          </TileMatrixLimits>
+        </TileMatrixSetLimits>
       </TileMatrixSetLink>
     </Layer>
 
@@ -2325,6 +2473,43 @@ sqs:
             r"""{DATE}/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.png" />
       <TileMatrixSetLink>
         <TileMatrixSet>swissgrid</TileMatrixSet>
+        <TileMatrixSetLimits>
+          <TileMatrixLimits>
+            <TileMatrix>0</TileMatrix>
+            <MinTileRow>6</MinTileRow>
+            <MaxTileRow>7</MaxTileRow>
+            <MinTileCol>5</MinTileCol>
+            <MaxTileCol>5</MaxTileCol>
+          </TileMatrixLimits>
+          <TileMatrixLimits>
+            <TileMatrix>1</TileMatrix>
+            <MinTileRow>13</MinTileRow>
+            <MaxTileRow>14</MaxTileRow>
+            <MinTileCol>10</MinTileCol>
+            <MaxTileCol>10</MaxTileCol>
+          </TileMatrixLimits>
+          <TileMatrixLimits>
+            <TileMatrix>2</TileMatrix>
+            <MinTileRow>33</MinTileRow>
+            <MaxTileRow>35</MaxTileRow>
+            <MinTileCol>25</MinTileCol>
+            <MaxTileCol>27</MaxTileCol>
+          </TileMatrixLimits>
+          <TileMatrixLimits>
+            <TileMatrix>3</TileMatrix>
+            <MinTileRow>66</MinTileRow>
+            <MaxTileRow>70</MaxTileRow>
+            <MinTileCol>50</MinTileCol>
+            <MaxTileCol>54</MaxTileCol>
+          </TileMatrixLimits>
+          <TileMatrixLimits>
+            <TileMatrix>4</TileMatrix>
+            <MinTileRow>132</MinTileRow>
+            <MaxTileRow>140</MaxTileRow>
+            <MinTileCol>101</MinTileCol>
+            <MaxTileCol>109</MaxTileCol>
+          </TileMatrixLimits>
+        </TileMatrixSetLimits>
       </TileMatrixSetLink>
     </Layer>
 

--- a/tilecloud_chain/tests/test_serve.py
+++ b/tilecloud_chain/tests/test_serve.py
@@ -334,6 +334,43 @@ class TestServe(CompareCase):
                 """{DATE}/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.png" />
         <TileMatrixSetLink>
           <TileMatrixSet>swissgrid_5</TileMatrixSet>
+          <TileMatrixSetLimits>
+            <TileMatrixLimits>
+              <TileMatrix>0</TileMatrix>
+              <MinTileRow>6</MinTileRow>
+              <MaxTileRow>7</MaxTileRow>
+              <MinTileCol>5</MinTileCol>
+              <MaxTileCol>5</MaxTileCol>
+            </TileMatrixLimits>
+            <TileMatrixLimits>
+              <TileMatrix>1</TileMatrix>
+              <MinTileRow>13</MinTileRow>
+              <MaxTileRow>14</MaxTileRow>
+              <MinTileCol>10</MinTileCol>
+              <MaxTileCol>10</MaxTileCol>
+            </TileMatrixLimits>
+            <TileMatrixLimits>
+              <TileMatrix>2</TileMatrix>
+              <MinTileRow>33</MinTileRow>
+              <MaxTileRow>35</MaxTileRow>
+              <MinTileCol>25</MinTileCol>
+              <MaxTileCol>27</MaxTileCol>
+            </TileMatrixLimits>
+            <TileMatrixLimits>
+              <TileMatrix>3</TileMatrix>
+              <MinTileRow>66</MinTileRow>
+              <MaxTileRow>70</MaxTileRow>
+              <MinTileCol>50</MinTileCol>
+              <MaxTileCol>54</MaxTileCol>
+            </TileMatrixLimits>
+            <TileMatrixLimits>
+              <TileMatrix>4</TileMatrix>
+              <MinTileRow>132</MinTileRow>
+              <MaxTileRow>140</MaxTileRow>
+              <MinTileCol>101</MinTileCol>
+              <MaxTileCol>109</MaxTileCol>
+            </TileMatrixLimits>
+          </TileMatrixSetLimits>
         </TileMatrixSetLink>
       </Layer>
 
@@ -553,6 +590,43 @@ class TestServe(CompareCase):
                      template="http://wmts1/tiles/1.0.0/point_webp/default/{DATE}/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.webp" />
         <TileMatrixSetLink>
           <TileMatrixSet>swissgrid_5</TileMatrixSet>
+          <TileMatrixSetLimits>
+            <TileMatrixLimits>
+              <TileMatrix>0</TileMatrix>
+              <MinTileRow>7</MinTileRow>
+              <MaxTileRow>12</MaxTileRow>
+              <MinTileCol>0</MinTileCol>
+              <MaxTileCol>7</MaxTileCol>
+            </TileMatrixLimits>
+            <TileMatrixLimits>
+              <TileMatrix>1</TileMatrix>
+              <MinTileRow>15</MinTileRow>
+              <MaxTileRow>24</MaxTileRow>
+              <MinTileCol>0</MinTileCol>
+              <MaxTileCol>14</MaxTileCol>
+            </TileMatrixLimits>
+            <TileMatrixLimits>
+              <TileMatrix>2</TileMatrix>
+              <MinTileRow>39</MinTileRow>
+              <MaxTileRow>62</MaxTileRow>
+              <MinTileCol>0</MinTileCol>
+              <MaxTileCol>35</MaxTileCol>
+            </TileMatrixLimits>
+            <TileMatrixLimits>
+              <TileMatrix>3</TileMatrix>
+              <MinTileRow>78</MinTileRow>
+              <MaxTileRow>124</MaxTileRow>
+              <MinTileCol>0</MinTileCol>
+              <MaxTileCol>70</MaxTileCol>
+            </TileMatrixLimits>
+            <TileMatrixLimits>
+              <TileMatrix>4</TileMatrix>
+              <MinTileRow>156</MinTileRow>
+              <MaxTileRow>249</MaxTileRow>
+              <MinTileCol>0</MinTileCol>
+              <MaxTileCol>140</MaxTileCol>
+            </TileMatrixLimits>
+          </TileMatrixSetLimits>
         </TileMatrixSetLink>
       </Layer>
 


### PR DESCRIPTION
## Summary
- add WMTS `TileMatrixSetLimits` generation in capabilities when a layer defines a `bbox`
- expose the limits helper to the capabilities template and render `<TileMatrixLimits>` per zoom level
- update documentation and controller capability snapshots to cover the new advertised limits

Closes #145