### PR TITLE
Restore PostgreSQL admin zoom status counters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Add `TileMatrixSetLimits` entries in WMTS capabilities when a layer defines a `bbox`, so clients can restrict tile requests to the advertised extent.
 - Add `generate-tiles --tile <z/x/y>` support to generate a specific tile or metatile without preparing a tiles file.
 - Expose `--tile` in admin command validation and command help examples.
+- Restore per-zoom admin job status counters for PostgreSQL queue jobs by correctly wiring the master generation queue store.
 
 Environment variable migration (legacy -> new)
 

--- a/tilecloud_chain/generate.py
+++ b/tilecloud_chain/generate.py
@@ -136,6 +136,8 @@ class Generate:
         if self._options.role in ("master", "slave") and not self._options.tiles:
             main_config = await self._gene.get_main_config()
             self._queue_tilestore = await get_queue_store(main_config, self._options.daemon)
+            if self._options.role == "master":
+                self._gene.init(self._queue_tilestore, daemon=self._options.daemon)
 
         if self._options.role in ("local", "master"):
             self._gene.add_geom_filter()

--- a/tilecloud_chain/tests/test_generate.py
+++ b/tilecloud_chain/tests/test_generate.py
@@ -1,8 +1,11 @@
 import json
 import os
 import shutil
+from argparse import Namespace
 from itertools import product, repeat
 from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
 
 import pytest
 from anyio import Path as AnyioPath
@@ -13,6 +16,41 @@ from tilecloud.store.redis import RedisTileStore
 from tilecloud_chain import controller, generate
 from tilecloud_chain.settings import settings
 from tilecloud_chain.tests import CompareCase
+
+
+@pytest.mark.asyncio
+async def test_master_initializes_tilegeneration_with_queue_store(monkeypatch: pytest.MonkeyPatch) -> None:
+    queue_store = object()
+
+    async def fake_get_queue_store(_config: object, _daemon: bool) -> object:
+        return queue_store
+
+    monkeypatch.setattr(generate, "get_queue_store", fake_get_queue_store)
+
+    gene = Mock()
+    gene.get_main_config = AsyncMock(return_value=SimpleNamespace(config={}))
+    gene.add_geom_filter = Mock()
+    gene.imap = Mock()
+    gene.add_logger = Mock()
+    gene.put = Mock()
+    gene.counter = Mock(return_value=object())
+    gene.init = Mock()
+
+    generate_ = generate.Generate(
+        Namespace(
+            get_hash=None,
+            tiles=None,
+            role="master",
+            daemon=False,
+            local_process_number=None,
+        ),
+        gene,
+        out=None,
+    )
+
+    await generate_._generate_init()  # noqa: SLF001
+
+    gene.init.assert_called_once_with(queue_store, daemon=False)
 
 
 class TestGenerate(CompareCase):


### PR DESCRIPTION
## Summary
- Reconnect the master generation flow to the shared queue store initialization so PostgreSQL queue-backed jobs keep accurate per-zoom counters in admin status.
- Add a regression test that verifies master mode initializes tile generation with the queue store while preparing queue jobs.
- Document the fix in the changelog.