### PR TITLE
Open new and pending jobs by default in admin accordion

### DIFF
--- a/tilecloud_chain/templates/admin_index.html
+++ b/tilecloud_chain/templates/admin_index.html
@@ -156,10 +156,11 @@
       <div class="accordion-item">
         <h2 class="accordion-header">
           <button
-            class="accordion-button collapsed"
+            class="accordion-button {% if job.status in ('created', 'pending') %}{% else %}collapsed{% endif %}"
             type="button"
             data-bs-toggle="collapse"
             data-bs-target="#collapse{{ loop.index0 }}"
+            aria-expanded="{% if job.status in ('created', 'pending') %}true{% else %}false{% endif %}"
             aria-controls="collapse{{ loop.index0 }}"
           >
             {{ job.name }} (
@@ -174,7 +175,10 @@
             <!-- {{ job.id }} -->
           </button>
         </h2>
-        <div id="collapse{{ loop.index0 }}" class="accordion-collapse collapse">
+        <div
+          id="collapse{{ loop.index0 }}"
+          class="accordion-collapse collapse {% if job.status in ('created', 'pending') %}show{% endif %}"
+        >
           <div class="accordion-body">
             <p>
               <code>{{ job.command }}</code>


### PR DESCRIPTION
## Summary
- Expand job accordion panels by default when job status is `created` or `pending`.
- Keep other job statuses collapsed by default and set matching `aria-expanded` values.