### PR TITLE
Open started jobs by default in admin accordion

### DIFF
--- a/tilecloud_chain/templates/admin_index.html
+++ b/tilecloud_chain/templates/admin_index.html
@@ -156,11 +156,11 @@
       <div class="accordion-item">
         <h2 class="accordion-header">
           <button
-            class="accordion-button {% if job.status in ('created', 'pending') %}{% else %}collapsed{% endif %}"
+            class="accordion-button {% if job.status in ('created', 'pending', 'started') %}{% else %}collapsed{% endif %}"
             type="button"
             data-bs-toggle="collapse"
             data-bs-target="#collapse{{ loop.index0 }}"
-            aria-expanded="{% if job.status in ('created', 'pending') %}true{% else %}false{% endif %}"
+            aria-expanded="{% if job.status in ('created', 'pending', 'started') %}true{% else %}false{% endif %}"
             aria-controls="collapse{{ loop.index0 }}"
           >
             {{ job.name }} (
@@ -177,7 +177,7 @@
         </h2>
         <div
           id="collapse{{ loop.index0 }}"
-          class="accordion-collapse collapse {% if job.status in ('created', 'pending') %}show{% endif %}"
+          class="accordion-collapse collapse {% if job.status in ('created', 'pending', 'started') %}show{% endif %}"
         >
           <div class="accordion-body">
             <p>


### PR DESCRIPTION
## Summary
- Keep accordion entries expanded by default when a job is in `started` status.
- Align button collapsed state and `aria-expanded` with the same status logic.
- Preserve existing behavior for other statuses.