### PR TITLE
Fix generate-controller status with PostgreSQL queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Add `generate-tiles --tile <z/x/y>` support to generate a specific tile or metatile without preparing a tiles file.
 - Expose `--tile` in admin command validation and command help examples.
 - Restore per-zoom admin job status counters for PostgreSQL queue jobs by correctly wiring the master generation queue store.
+- Fix `generate-controller --status` on PostgreSQL queue configurations so it reports job status instead of failing with a `KeyError`.
 
 Environment variable migration (legacy -> new)
 

--- a/tilecloud_chain/USAGE.rst
+++ b/tilecloud_chain/USAGE.rst
@@ -677,6 +677,15 @@ Generate a tiles in a different cache than the default one:
 
     generate-tiles --cache <a_cache>
 
+Display queue status:
+
+.. prompt:: bash
+
+    generate-controller --status
+
+With Redis/SQS this prints queue counters. With PostgreSQL this prints the job list with
+per-job counters (to generate, pending, in error) and ETA when available.
+
 
 Explain cost
 ------------

--- a/tilecloud_chain/controller.py
+++ b/tilecloud_chain/controller.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass
 from hashlib import sha1
 from io import BytesIO, StringIO
 from math import exp, log
-from typing import IO, Literal, cast
+from typing import IO, cast
 from urllib.parse import urlencode
 
 import PIL.ImageFile
@@ -70,7 +70,7 @@ async def async_main(args: list[str] | None = None, out: IO[str] | None = None) 
             "--status",
             default=False,
             action="store_true",
-            help="Display the SQS queue status and exit",
+            help="Display the queue status and exit",
         )
         parser.add_argument(
             "--legends",
@@ -406,9 +406,42 @@ async def get_status(gene: TileGeneration) -> list[str]:
     """Get the tile generation status."""
     config = await gene.get_main_config()
     store = await get_queue_store(config, daemon=False)
-    type_: Literal["redis", "sqs"] = "redis" if "redis" in config.config else "sqs"
-    conf = config.config[type_]
-    with _GET_STATUS_SUMMARY.labels(type_, conf.get("queue", configuration.REDIS_QUEUE_DEFAULT)).time():
+    queue_store = config.config.get("queue_store", configuration.QUEUE_STORE_DEFAULT)
+    if queue_store == "postgresql":
+        with _GET_STATUS_SUMMARY.labels("postgresql", "postgresql").time():
+            jobs_status = await store.get_status(config.file)
+
+        if not jobs_status:
+            return ["Number of jobs: 0"]
+
+        lines = [f"Number of jobs: {len(jobs_status)}"]
+        for job, status_by_zoom, errors, eta in jobs_status:
+            nb_generate = sum(data.get("generate", 0) for data in status_by_zoom)
+            nb_pending = sum(data.get("pending", 0) for data in status_by_zoom)
+            nb_error = sum(data.get("error", 0) for data in status_by_zoom)
+            lines.extend(
+                [
+                    f"Job {job.id} ({job.name}) [{job.status}]",
+                    f"  To generate: {nb_generate}",
+                    f"  Pending: {nb_pending}",
+                    f"  In error: {nb_error}",
+                    f"  ETA: {eta or '-'}",
+                ],
+            )
+            if errors:
+                lines.append(f"  Last error: {errors[0]}")
+        return lines
+
+    type_ = "redis" if queue_store == "redis" else "sqs"
+    queue_name: str
+    if type_ == "redis":
+        redis_conf = config.config.get("redis", {})
+        queue_name = redis_conf.get("queue", configuration.REDIS_QUEUE_DEFAULT)
+    else:
+        sqs_conf = config.config.get("sqs", {})
+        queue_name = sqs_conf.get("queue", configuration.SQS_QUEUE_DEFAULT)
+
+    with _GET_STATUS_SUMMARY.labels(type_, queue_name).time():
         status_ = store.get_status()
     return [name + ": " + str(value) for name, value in status_.items()]
 

--- a/tilecloud_chain/tests/test_postgresql.py
+++ b/tilecloud_chain/tests/test_postgresql.py
@@ -4,12 +4,13 @@ from pathlib import Path
 
 import pytest
 import pytest_asyncio
+from anyio import Path as AnyioPath
 from sqlalchemy import and_
 from sqlalchemy.engine import create_engine
 from sqlalchemy.orm import sessionmaker
 from tilecloud import Tile, TileCoord
 
-from tilecloud_chain import DatedConfig
+from tilecloud_chain import DatedConfig, TileGeneration, controller
 from tilecloud_chain.settings import settings
 from tilecloud_chain.store.postgresql import (
     _STATUS_CANCELLED,
@@ -292,3 +293,42 @@ async def test_put_one_batch_insert(SessionMaker: sessionmaker, monkeypatch: pyt
         session.query(Queue).filter(Queue.job_id == job_id).delete()
         session.query(Job).filter(Job.id == job_id).delete()
         session.commit()
+
+
+@pytest.mark.asyncio
+async def test_controller_status_postgresql(SessionMaker: sessionmaker) -> None:
+    config_filename = AnyioPath(str(Path(__file__).parent / "tilegeneration/test-postgresql.yaml"))
+    gene = TileGeneration(config_filename, configure_logging=False)
+    await gene.ainit()
+    job_id = None
+    try:
+        status_lines = await controller.get_status(gene)
+        assert "Number of jobs: 0" in status_lines
+
+        tilestore = await get_postgresql_queue_store(DatedConfig({}, 0, config_filename))
+        await tilestore.create_job(
+            "status-job",
+            "generate-tiles --layer=point",
+            config_filename,
+        )
+        with SessionMaker() as session:
+            job = session.query(Job).filter(Job.name == "status-job").one()
+            job.status = _STATUS_STARTED
+            job_id = job.id
+            session.commit()
+
+        await tilestore.put_one(Tile(TileCoord(0, 0, 0), metadata={"job_id": job_id}))
+        await tilestore.close()
+
+        status_lines = await controller.get_status(gene)
+        status_text = "\n".join(status_lines)
+        assert "Number of jobs:" in status_text
+        assert f"Job {job_id} (status-job) [started]" in status_text
+        assert "  To generate: 1" in status_text
+    finally:
+        if job_id is not None:
+            with SessionMaker() as session:
+                session.query(Queue).filter(Queue.job_id == job_id).delete()
+                session.query(Job).filter(Job.id == job_id).delete()
+                session.commit()
+        await gene.close()

--- a/tilecloud_chain/tests/tilegeneration/test-postgresql.yaml
+++ b/tilecloud_chain/tests/tilegeneration/test-postgresql.yaml
@@ -1,0 +1,50 @@
+queue_store: postgresql
+
+grids:
+  swissgrid_5:
+    resolutions: [100, 50, 20, 10, 5]
+    bbox: [420000, 30000, 900000, 350000]
+    tile_size: 256
+    srs: EPSG:21781
+
+caches:
+  local:
+    type: filesystem
+    http_url: http://wmts1/tiles/
+    folder: /tmp/tiles
+    wmtscapabilities_file: 1.0.0/WMTSCapabilities.xml
+
+defaults:
+  layer: &layer
+    grids: [swissgrid_5]
+    type: wms
+    url: http://mapserver:8080/
+    wmts_style: default
+    mime_type: image/png
+    extension: png
+    dimensions:
+      - name: DATE
+        default: '2012'
+        generate: ['2012']
+        values: ['2012']
+    meta: true
+    meta_size: 8
+    meta_buffer: 128
+
+layers:
+  point:
+    <<: *layer
+    layers: point
+    geoms:
+      - sql: the_geom AS geom FROM tests.point
+        connection: user=postgresql password=postgresql dbname=tests host=db
+    min_resolution_seed: 10
+
+generation:
+  default_cache: local
+  default_layers: [point]
+  maxconsecutive_errors: 2
+  error_file: error.list
+
+postgresql:
+  sqlalchemy_url: postgresql+psycopg://postgresql:postgresql@db:5432/tests


### PR DESCRIPTION
## Summary
- fix `generate-controller --status` to support `queue_store: postgresql` instead of crashing with `KeyError: 'sqs'`
- keep Redis/SQS status output unchanged and update the `--status` help text to be queue-agnostic
- add PostgreSQL regression coverage for controller status and a dedicated PostgreSQL test config fixture
- document the CLI status behavior in `USAGE.rst` and add the user-facing note in `CHANGELOG.md`