### PR TITLE
Fix WMS error formatting and admin job spacing

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,3 @@
 poetry.lock
 tilecloud_chain/CONFIG.md
+tilecloud_chain/templates/admin_index.html

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Expose `--tile` in admin command validation and command help examples.
 - Restore per-zoom admin job status counters for PostgreSQL queue jobs by correctly wiring the master generation queue store.
 - Fix `generate-controller --status` on PostgreSQL queue configurations so it reports job status instead of failing with a `KeyError`.
+- Keep WMS XML error newlines in tile error logs and remove extra spaces in the admin job status header `(date, status)` display.
 
 Environment variable migration (legacy -> new)
 

--- a/tilecloud_chain/USAGE.rst
+++ b/tilecloud_chain/USAGE.rst
@@ -414,7 +414,7 @@ Is it possible to store the queue in a PostgreSQL database, for that you should 
 configuration file or in the ``TILECLOUD_CHAIN__POSTGRESQL__SQLALCHEMY_URL`` environment variable.
 
 Queue inserts are batched to improve performance when generating very large pyramids. The default
-batch size is ``10000`` rows and can be changed with
+batch size is ``100`` rows and can be changed with
 ``TILECLOUD_CHAIN__POSTGRESQL__QUEUE_INSERT_BATCH_SIZE``.
 
 See the [configuration reference](https://github.com/camptocamp/tilecloud-chain/blob/master/tilecloud_chain/CONFIG.md#definitions/postgresql) for the other configuration possibilities.

--- a/tilecloud_chain/__init__.py
+++ b/tilecloud_chain/__init__.py
@@ -238,7 +238,7 @@ class Run:
     Manage the max_consecutive_errors.
     """
 
-    _re_rm_xml_tag = re.compile("(<[^>]*>|\n)")
+    _re_rm_xml_tag = re.compile("<[^>]*>")
     max_consecutive_errors: MaximumConsecutiveErrors | None
 
     def __init__(

--- a/tilecloud_chain/settings.py
+++ b/tilecloud_chain/settings.py
@@ -104,7 +104,7 @@ class PostgresqlSettings(BaseModel):
 
     schema_name: str = "tilecloud_chain"
     sqlalchemy_url: str | None = None
-    queue_insert_batch_size: int = 10000
+    queue_insert_batch_size: int = 100
     objgraph_postgresql: bool = False
     objgraph_limit: int = 10
 

--- a/tilecloud_chain/templates/admin_index.html
+++ b/tilecloud_chain/templates/admin_index.html
@@ -163,12 +163,7 @@
             aria-expanded="{% if job.status in ('created', 'pending', 'started') %}true{% else %}false{% endif %}"
             aria-controls="collapse{{ loop.index0 }}"
           >
-            {{ job.name }} (
-            <script nonce="{{ nonce }}">
-              window.document.write(new Date('{{ job.created_at.isoformat() }}').toLocaleString());
-            </script>
-            ,
-            <span
+            {{ job.name }} (<script nonce="{{ nonce }}">globalThis.document.write(new Date('{{ job.created_at.isoformat() }}').toLocaleString());</script>, <span
               class="badge {% if job.status == 'started' %}text-bg-success{% elif job.status == 'error' %}text-bg-danger{% elif job.status == 'done' %}text-bg-primary{% elif job.status == 'cancelled' %}text-bg-secondary{% else %}text-bg-light text-dark{% endif %}"
               >{{ job.status }}</span
             >)

--- a/tilecloud_chain/tests/test_generate.py
+++ b/tilecloud_chain/tests/test_generate.py
@@ -1088,24 +1088,25 @@ Size per tile: 4[0-9][0-9] o
                             r"Start the layer 'point_error' generation",
                             r"0/0/0:\+8/\+8 config_file=tilegeneration/test-nosns.yaml dimension_DATE=2012 "
                             r"grid=swissgrid_5 host=localhost layer=point_error # \[[0-9][0-9]-[0-9][0-9]-20[0-9][0-9] "
-                            r"[0-9][0-9]:[0-9][0-9]:[0-9][0-9]\] 'WMS server error: URL: http:[^ ]+"
+                            r"[0-9][0-9]:[0-9][0-9]:[0-9][0-9]\] 'WMS server error: URL: http:[^ ]+?(?:\\n|\s)+"
                             r"msWMSLoadGetMapParams\(\): "
                             r"WMS server error\. Invalid layer\(s\) given in the LAYERS parameter\. "
                             r"A layer might be disabled for this request\. Check wms/ows_enable_request "
-                            r"settings\.'",
+                            r"settings\.(?:\\n|\s)*'",
                             r"0/0/8:\+8/\+8 config_file=tilegeneration/test-nosns.yaml dimension_DATE=2012 "
                             r"grid=swissgrid_5 host=localhost layer=point_error # \[[0-9][0-9]-[0-9][0-9]-20[0-9][0-9] "
-                            r"[0-9][0-9]:[0-9][0-9]:[0-9][0-9]\] 'WMS server error: URL: http:[^ ]+"
+                            r"[0-9][0-9]:[0-9][0-9]:[0-9][0-9]\] 'WMS server error: URL: http:[^ ]+?(?:\\n|\s)+"
                             r"msWMSLoadGetMapParams\(\): "
                             r"WMS server error\. Invalid layer\(s\) given in the LAYERS parameter\. "
                             r"A layer might be disabled for this request\. Check wms/ows_enable_request "
-                            r"settings\.'",
+                            r"settings\.(?:\\n|\s)*'",
                             r"0/8/0:\+8/\+8 config_file=tilegeneration/test-nosns.yaml dimension_DATE=2012 "
                             r"grid=swissgrid_5 host=localhost layer=point_error # \[[0-9][0-9]-[0-9][0-9]-20[0-9][0-9] "
-                            r"[0-9][0-9]:[0-9][0-9]:[0-9][0-9]\] 'WMS server error: URL: http:[^ ]+"
+                            r"[0-9][0-9]:[0-9][0-9]:[0-9][0-9]\] 'WMS server error: URL: http:[^ ]+?(?:\\n|\s)+"
                             r"msWMSLoadGetMapParams\(\): "
                             r"WMS server error\. Invalid layer\(s\) given in the LAYERS parameter\. "
-                            r"A layer might be disabled for this request\. Check wms/ows_enable_request settings\.'",
+                            r"A layer might be disabled for this request\. Check wms/ows_enable_request "
+                            r"settings\.(?:\\n|\s)*'",
                             "",
                         ],
                     ),


### PR DESCRIPTION
## Summary
- keep newline separators when sanitizing WMS XML/HTML error payloads so URL parameters and HTTP status stay readable in tile error logs
- update the related error-file regex expectations to accept preserved whitespace between URL and MapServer message
- remove extra spaces around the admin jobs header date/status rendering to display `(date, done)` without padding artifacts