### PR TITLE
Auto-create PostgreSQL jobs for master runs and update CLI docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,12 @@ Branch names should not contain `/`.
 
 Use the long parameter names for clarity and maintainability.
 
+## CLI documentation
+
+In examples, use `--argument=value` style for single-value options.
+Keep space-separated values for multi-value options (for example
+`--bbox <MINX> <MINY> <MAXX> <MAXY>` and `--near <X> <Y>`).
+
 ## Dependencies
 
 In the `pyproject.toml` file the `project.dependencies` are managed automatically,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,11 +17,12 @@
 - Update example tilegeneration configs to enable tile optimization (`post_process` with `optipng`/`jpegoptim` and Pillow `meta_save_options`).
 - Document how to combine `post_process` and `meta_save_options` to optimize PNG/JPEG tiles.
 - Add `TileMatrixSetLimits` entries in WMTS capabilities when a layer defines a `bbox`, so clients can restrict tile requests to the advertised extent.
-- Add `generate-tiles --tile <z/x/y>` support to generate a specific tile or metatile without preparing a tiles file.
+- Add `generate-tiles --tile=<z/x/y>` support to generate a specific tile or metatile without preparing a tiles file.
 - Expose `--tile` in admin command validation and command help examples.
 - Restore per-zoom admin job status counters for PostgreSQL queue jobs by correctly wiring the master generation queue store.
 - Fix `generate-controller --status` on PostgreSQL queue configurations so it reports job status instead of failing with a `KeyError`.
 - Keep WMS XML error newlines in tile error logs and remove extra spaces in the admin job status header `(date, status)` display.
+- Auto-create a PostgreSQL job when `generate-tiles --role=master` runs without `--job-id`, using `User call` as default title and allowing override with `--job-title=<title>`.
 
 Environment variable migration (legacy -> new)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,7 +8,7 @@
 ## Release 1.17
 
 1. Change the validator and parser => duplicate key generate an error: on/off are no more considered as boolean.
-2. The argument --layer is no more used when we use the parameter --tiles, we get the information from the
+2. The argument --layer=<a_layer> is no more used when we use the parameter --tiles=<path/to/file>, we get the information from the
    tiles file.
 3. Be able to mutualise the service.
 4. Add Azure blob storage

--- a/tilecloud_chain/USAGE.rst
+++ b/tilecloud_chain/USAGE.rst
@@ -152,7 +152,7 @@ To easily generate this configuration we can use the following command:
 
 ::
 
-    generate-tiles --get-hash <z/x/y> -l <layer_name>
+    generate-tiles --get-hash=<z/x/y> --layer=<layer_name>
 
 Where ``<z/x/y>`` should refer to an empty tile/metatile. Generally it's a good idea to use z as the maximum
 zoom, x and y as 0.
@@ -354,7 +354,7 @@ If we set a file path in configuration file:
         error_file: <path>
 
 The tiles that's in error will be append to the file, ant the tiles can be regenerated with
-``generate-tiles --tiles <path>``.
+``generate-tiles --tiles=<path>``.
 
 The ``<path>`` can be ``/tmp/error_{layer}_{datetime:%Y-%m-%d_%H:%M:%S}`` to have one file per layer and per
 run.
@@ -478,20 +478,20 @@ To use the SQS queue we should first fill the queue:
 
 .. prompt:: bash
 
-    generate-tiles --role master --layer <a_layer>
+    generate-tiles --role=master --layer=<a_layer>
 
 And then generate the tiles present in the SQS queue:
 
 .. prompt:: bash
 
-    generate-tiles --role slave --layer <a_layer>
+    generate-tiles --role=slave --layer=<a_layer>
 
 For the slave to keep listening when the queue is empty and be able to support more than one layer, you must
 enable the daemon mode and must not specify the layer:
 
 .. prompt:: bash
 
-    generate-tiles --role slave --daemon
+    generate-tiles --role=slave --daemon
 
 Configure SNS
 ~~~~~~~~~~~~~
@@ -618,43 +618,43 @@ Generate a specific layer:
 
 .. prompt:: bash
 
-    generate-tiles --layer <a_layer>
+    generate-tiles --layer=<a_layer>
 
 Generate a specific zoom:
 
 .. prompt:: bash
 
-    generate-tiles --zoom 5
+    generate-tiles --zoom=5
 
 Generate a specific zoom range:
 
 .. prompt:: bash
 
-    generate-tiles --zoom 2-8
+    generate-tiles --zoom=2-8
 
 Generate a specific some zoom levels:
 
 .. prompt:: bash
 
-    generate-tiles --zoom 2,4,7
+    generate-tiles --zoom=2,4,7
 
 Generate tiles from an (error) tiles file:
 
 .. prompt:: bash
 
-    generate-tiles --layer <a_layer> --tiles <path/to/error.list>
+    generate-tiles --layer=<a_layer> --tiles=<path/to/error.list>
 
 Generate a specific tile:
 
 .. prompt:: bash
 
-    generate-tiles --layer <a_layer> --tile <z/x/y>
+    generate-tiles --layer=<a_layer> --tile=<z/x/y>
 
 Generate a specific metatile:
 
 .. prompt:: bash
 
-    generate-tiles --layer <a_layer> --tile <z/x/y:+n/+n>
+    generate-tiles --layer=<a_layer> --tile=<z/x/y:+n/+n>
 
 In the admin page command form, this option is available as well if ``--tile`` is in
 ``server.allowed_arguments`` (it is included by default).
@@ -675,7 +675,12 @@ Generate a tiles in a different cache than the default one:
 
 .. prompt:: bash
 
-    generate-tiles --cache <a_cache>
+    generate-tiles --cache=<a_cache>
+
+With the PostgreSQL queue store, running ``generate-tiles --role=master`` without
+``--job-id`` now auto-creates a job and attaches generated metatiles to it.
+The default auto-created job title is ``User call``, and you can override it
+with ``--job-title=<title>``.
 
 Display queue status:
 
@@ -735,7 +740,7 @@ Useful options
 ``--debug`` or ``-d``: used to display debug message, please use this option to report issue. With the debug
 mode we don't catch exceptions, and we don't log time messages.
 
-``--test <n>`` or ``-t <n>``: used to generate only ``<n>`` tiles, useful for test.
+``--test=<n>`` or ``-t <n>``: used to generate only ``<n>`` tiles, useful for test.
 
 
 Mutualized

--- a/tilecloud_chain/generate.py
+++ b/tilecloud_chain/generate.py
@@ -624,6 +624,69 @@ def detach() -> None:
         sys.exit(1)
 
 
+async def _ensure_postgresql_job_id(
+    options: Namespace,
+    gene: TileGeneration,
+    args: list[str] | None = None,
+) -> bool:
+    if options.role != "master" or options.job_id is not None:
+        return False
+    if options.get_hash is not None or options.get_bbox is not None or options.tiles is not None:
+        return False
+
+    main_config = await gene.get_main_config()
+    if main_config.config.get("queue_store", configuration.QUEUE_STORE_DEFAULT) != "postgresql":
+        return False
+
+    queue_store = await get_queue_store(main_config, options.daemon)
+    try:
+        if not hasattr(queue_store, "create_job"):
+            return False
+
+        command_arguments = args if args is not None else sys.argv
+        command_arguments = _normalize_job_command_arguments(command_arguments)
+        job_title = options.job_title or "User call"
+        command = " ".join(quote(argument) for argument in command_arguments)
+        options.job_id = await queue_store.create_job(
+            job_title,
+            command,
+            main_config.file,
+            initial_status="pending",
+        )
+        return True
+    finally:
+        await queue_store.close()
+
+
+async def _activate_postgresql_job(options: Namespace, queue_store: AsyncTileStore | None) -> None:
+    if queue_store is None or options.job_id is None:
+        return
+
+    await queue_store.close()
+    if hasattr(queue_store, "start_job"):
+        await queue_store.start_job(options.job_id)
+
+
+def _normalize_job_command_arguments(arguments: list[str]) -> list[str]:
+    normalized_arguments: list[str] = []
+    skip_next = False
+    for argument in arguments:
+        if skip_next:
+            skip_next = False
+            continue
+        if argument == "--job-title":
+            skip_next = True
+            continue
+        if argument.startswith("--job-title="):
+            continue
+        normalized_arguments.append(argument)
+
+    if normalized_arguments:
+        normalized_arguments[0] = Path(normalized_arguments[0]).name
+
+    return normalized_arguments
+
+
 def main(args: list[str] | None = None, out: IO[str] | None = None) -> None:
     """Run the tiles generation."""
     asyncio.run(async_main(args, out))
@@ -686,8 +749,16 @@ async def async_main(args: list[str] | None = None, out: IO[str] | None = None) 
             help="The job id in case of Postgres queue",
             type=int,
         )
+        parser.add_argument(
+            "--job-title",
+            help="The title used when auto-creating a PostgreSQL job in master mode",
+        )
 
         options = parser.parse_args(args[1:] if args else sys.argv[1:])
+
+        if options.job_id is not None and options.job_title is not None:
+            _LOGGER.error("The --job-id and --job-title options are mutually exclusive")
+            sys.exit(1)
 
         if options.detach:
             detach()
@@ -745,6 +816,8 @@ async def async_main(args: list[str] | None = None, out: IO[str] | None = None) 
             _LOGGER.error("With --tile option you need to specify a layer")
             sys.exit(1)
 
+        auto_created_postgresql_job = await _ensure_postgresql_job_id(options, gene, args)
+
         try:
             generate = Generate(options, gene, out)
             await generate.init()
@@ -764,6 +837,9 @@ async def async_main(args: list[str] | None = None, out: IO[str] | None = None) 
                     config.config.get("layers", {}).keys(),
                 ):
                     await generate.gene(layer)
+
+            if auto_created_postgresql_job:
+                await _activate_postgresql_job(options, generate._queue_tilestore)  # noqa: SLF001
         except tilecloud.filter.error.TooManyErrors:
             _LOGGER.exception("Too many errors")
             sys.exit(1)

--- a/tilecloud_chain/store/postgresql.py
+++ b/tilecloud_chain/store/postgresql.py
@@ -394,12 +394,36 @@ class PostgresqlTileStore(AsyncTileStore):
 
         self.SessionMaker = async_sessionmaker(engine)  # pylint: disable=invalid-name
 
-    async def create_job(self, name: str, command: str, config_filename: Path) -> None:
+    async def create_job(
+        self,
+        name: str,
+        command: str,
+        config_filename: Path,
+        initial_status: str = _STATUS_CREATED,
+    ) -> int:
         """Create a job."""
         assert self.SessionMaker is not None
         async with self.SessionMaker() as session:
-            job = Job(name=name, command=command, config_filename=config_filename.as_posix())
+            job = Job(
+                name=name,
+                command=command,
+                config_filename=config_filename.as_posix(),
+                status=initial_status,
+            )
             session.add(job)
+            await session.commit()
+            await session.refresh(job)
+            return job.id
+
+    async def start_job(self, job_id: int) -> None:
+        """Mark a pending job as started."""
+        assert self.SessionMaker is not None
+        async with self.SessionMaker() as session:
+            await session.execute(
+                update(Job)
+                .where(and_(Job.id == job_id, Job.status == _STATUS_PENDING))
+                .values(status=_STATUS_STARTED, started_at=datetime.datetime.now(tz=datetime.UTC)),
+            )
             await session.commit()
 
     async def retry(self, job_id: int, config_filename: Path) -> None:

--- a/tilecloud_chain/tests/test_generate.py
+++ b/tilecloud_chain/tests/test_generate.py
@@ -53,6 +53,131 @@ async def test_master_initializes_tilegeneration_with_queue_store(monkeypatch: p
     gene.init.assert_called_once_with(queue_store, daemon=False)
 
 
+@pytest.mark.asyncio
+async def test_ensure_postgresql_job_id_uses_default_title(monkeypatch: pytest.MonkeyPatch) -> None:
+    queue_store = Mock()
+    queue_store.create_job = AsyncMock(return_value=42)
+    queue_store.close = AsyncMock()
+    monkeypatch.setattr(generate, "get_queue_store", AsyncMock(return_value=queue_store))
+
+    options = Namespace(
+        role="master",
+        job_id=None,
+        get_hash=None,
+        get_bbox=None,
+        tiles=None,
+        daemon=False,
+        job_title=None,
+    )
+    gene = Mock()
+    gene.get_main_config = AsyncMock(
+        return_value=SimpleNamespace(config={"queue_store": "postgresql"}, file=AnyioPath("config.yaml")),
+    )
+
+    await generate._ensure_postgresql_job_id(options, gene, ["generate-tiles", "--role", "master"])
+
+    assert options.job_id == 42
+    queue_store.create_job.assert_awaited_once_with(
+        "User call",
+        "generate-tiles --role master",
+        AnyioPath("config.yaml"),
+        initial_status="pending",
+    )
+
+
+@pytest.mark.asyncio
+async def test_ensure_postgresql_job_id_uses_custom_title(monkeypatch: pytest.MonkeyPatch) -> None:
+    queue_store = Mock()
+    queue_store.create_job = AsyncMock(return_value=84)
+    queue_store.close = AsyncMock()
+    monkeypatch.setattr(generate, "get_queue_store", AsyncMock(return_value=queue_store))
+
+    options = Namespace(
+        role="master",
+        job_id=None,
+        get_hash=None,
+        get_bbox=None,
+        tiles=None,
+        daemon=False,
+        job_title="custom-title",
+    )
+    gene = Mock()
+    gene.get_main_config = AsyncMock(
+        return_value=SimpleNamespace(config={"queue_store": "postgresql"}, file=AnyioPath("config.yaml")),
+    )
+
+    await generate._ensure_postgresql_job_id(options, gene, ["generate-tiles", "--role", "master"])
+
+    assert options.job_id == 84
+    queue_store.create_job.assert_awaited_once_with(
+        "custom-title",
+        "generate-tiles --role master",
+        AnyioPath("config.yaml"),
+        initial_status="pending",
+    )
+
+
+@pytest.mark.asyncio
+async def test_ensure_postgresql_job_id_removes_job_title_from_saved_command(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    queue_store = Mock()
+    queue_store.create_job = AsyncMock(return_value=84)
+    queue_store.close = AsyncMock()
+    monkeypatch.setattr(generate, "get_queue_store", AsyncMock(return_value=queue_store))
+
+    options = Namespace(
+        role="master",
+        job_id=None,
+        get_hash=None,
+        get_bbox=None,
+        tiles=None,
+        daemon=False,
+        job_title="custom-title",
+    )
+    gene = Mock()
+    gene.get_main_config = AsyncMock(
+        return_value=SimpleNamespace(config={"queue_store": "postgresql"}, file=AnyioPath("config.yaml")),
+    )
+
+    await generate._ensure_postgresql_job_id(
+        options,
+        gene,
+        ["/tmp/.build/venv/bin/generate-tiles", "--role", "master", "--job-title", "custom-title"],
+    )
+
+    queue_store.create_job.assert_awaited_once_with(
+        "custom-title",
+        "generate-tiles --role master",
+        AnyioPath("config.yaml"),
+        initial_status="pending",
+    )
+
+
+@pytest.mark.asyncio
+async def test_activate_postgresql_job(monkeypatch: pytest.MonkeyPatch) -> None:
+    queue_store = Mock()
+    queue_store.close = AsyncMock()
+    queue_store.start_job = AsyncMock()
+
+    options = Namespace(job_id=42)
+
+    await generate._activate_postgresql_job(options, queue_store)
+
+    queue_store.close.assert_awaited_once_with()
+    queue_store.start_job.assert_awaited_once_with(42)
+
+
+def test_normalize_job_command_arguments() -> None:
+    assert generate._normalize_job_command_arguments(
+        ["/tmp/.build/venv/bin/generate-tiles", "--role", "master", "--job-title", "my title"],
+    ) == ["generate-tiles", "--role", "master"]
+
+    assert generate._normalize_job_command_arguments(
+        ["/tmp/.build/venv/bin/generate-tiles", "--role", "master", "--job-title=my title"],
+    ) == ["generate-tiles", "--role", "master"]
+
+
 class TestGenerate(CompareCase):
     def setup_method(self) -> None:
         self.maxDiff = None
@@ -68,6 +193,16 @@ class TestGenerate(CompareCase):
         os.chdir(Path(__file__).parent.parent.parent)
         if Path("/tmp/tiles").exists():
             shutil.rmtree("/tmp/tiles")
+
+    @pytest.mark.asyncio
+    async def test_postgresql_master_job_id_and_job_title_are_mutually_exclusive(self) -> None:
+        await self.assert_cmd_exit_equals(
+            cmd=(
+                ".build/venv/bin/generate-tiles -c tilegeneration/test-postgresql.yaml "
+                "--role master -l point --job-id 1 --job-title custom-title"
+            ),
+            main_func=generate.async_main,
+        )
 
     @pytest.mark.asyncio
     async def test_get_hash(self) -> None:


### PR DESCRIPTION
## Summary
- Auto-create a PostgreSQL job for `generate-tiles --role=master` when no `--job-id` is provided, with `User call` as default title and optional `--job-title` override.
- Return created job IDs from the PostgreSQL queue store and keep auto-created jobs in `started` state to avoid duplicate scheduler launches.
- Update CLI/documentation examples to use `--argument=value` for single-value options while keeping spaced syntax for multi-value options (`--bbox`, `--near`), and document this rule in `AGENTS.md`.
- Add unit tests covering automatic PostgreSQL job creation, title handling, command normalization, and `--job-id`/`--job-title` exclusivity.