### PR TITLE
Speed up sparse master queue seeding with scanline intervals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@
 - Fix `generate-controller --status` on PostgreSQL queue configurations so it reports job status instead of failing with a `KeyError`.
 - Keep WMS XML error newlines in tile error logs and remove extra spaces in the admin job status header `(date, status)` display.
 - Auto-create a PostgreSQL job when `generate-tiles --role=master` runs without `--job-id`, using `User call` as default title and allowing override with `--job-title=<title>`.
-- Speed up sparse geometry queue seeding in `generate-tiles --role=master` by using per-row metatile scanline intervals instead of full bounding-pyramid scans, reducing candidate metatiles on sparse datasets.
+- Speed up `generate-tiles --role=master` queue seeding for metatile layers by using per-row metatile scanline intervals instead of full bounding-pyramid scans, reducing candidate metatiles especially on sparse datasets.
 
 Environment variable migration (legacy -> new)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Fix `generate-controller --status` on PostgreSQL queue configurations so it reports job status instead of failing with a `KeyError`.
 - Keep WMS XML error newlines in tile error logs and remove extra spaces in the admin job status header `(date, status)` display.
 - Auto-create a PostgreSQL job when `generate-tiles --role=master` runs without `--job-id`, using `User call` as default title and allowing override with `--job-title=<title>`.
+- Speed up sparse geometry queue seeding in `generate-tiles --role=master` by using per-row metatile scanline intervals instead of full bounding-pyramid scans, reducing candidate metatiles on sparse datasets.
 
 Environment variable migration (legacy -> new)
 

--- a/tilecloud_chain/USAGE.rst
+++ b/tilecloud_chain/USAGE.rst
@@ -682,10 +682,10 @@ With the PostgreSQL queue store, running ``generate-tiles --role=master`` withou
 The default auto-created job title is ``User call``, and you can override it
 with ``--job-title=<title>``.
 
-When seeding metatiles with ``--role=master``, sparse geometry layers are now
-seeded with a scanline strategy (per metatile row) to avoid scanning full
-bounding extents that mostly contain empty space. This reduces queue build time
-on sparse datasets while keeping geometry filtering in the generation pipeline.
+When seeding metatiles with ``--role=master``, metatile layers use a scanline
+strategy (per metatile row) instead of scanning full bounding extents. This is
+especially beneficial on sparse datasets, where it reduces queue build time,
+while keeping geometry filtering in the generation pipeline.
 
 Display queue status:
 

--- a/tilecloud_chain/USAGE.rst
+++ b/tilecloud_chain/USAGE.rst
@@ -682,6 +682,11 @@ With the PostgreSQL queue store, running ``generate-tiles --role=master`` withou
 The default auto-created job title is ``User call``, and you can override it
 with ``--job-title=<title>``.
 
+When seeding metatiles with ``--role=master``, sparse geometry layers are now
+seeded with a scanline strategy (per metatile row) to avoid scanning full
+bounding extents that mostly contain empty space. This reduces queue build time
+on sparse datasets while keeping geometry filtering in the generation pipeline.
+
 Display queue status:
 
 .. prompt:: bash

--- a/tilecloud_chain/__init__.py
+++ b/tilecloud_chain/__init__.py
@@ -21,7 +21,7 @@ from dataclasses import dataclass
 from fractions import Fraction
 from hashlib import sha1
 from io import BytesIO
-from itertools import product
+from itertools import chain, product
 from math import ceil, sqrt
 from typing import IO, TYPE_CHECKING, Any, Literal, NamedTuple, TextIO, TypedDict, cast
 
@@ -675,7 +675,7 @@ class TileGeneration:
         self.hosts_cache: DatedHosts | None = None
         self.meta_tilecoords_sparse_cache: dict[
             tuple[str, float, str, str, int, int, float, float],
-            list[TileCoord],
+            list[tuple[int, list[tuple[int, int]]]],
         ] = {}
 
         class Options(NamedTuple):
@@ -1542,7 +1542,7 @@ class TileGeneration:
         for sub_geometry in geometries:
             yield from TileGeneration._iter_leaf_geometries(sub_geometry)
 
-    def _get_sparse_metatilecoords(
+    def _get_sparse_metatile_intervals(
         self,
         config: DatedConfig,
         layer_name: str,
@@ -1552,8 +1552,8 @@ class TileGeneration:
         zoom: int,
         resolution: float,
         meta_size: int,
-        px_buffer: float,
-    ) -> list[TileCoord]:
+        px_buffer: int | float,
+    ) -> list[tuple[int, list[tuple[int, int]]]]:
         cache_key = (
             str(config.file),
             config.mtime,
@@ -1597,7 +1597,7 @@ class TileGeneration:
             return []
 
         row_start, row_end = row_range
-        metatilecoords: list[TileCoord] = []
+        row_intervals: list[tuple[int, list[tuple[int, int]]]] = []
         for row in range(row_start, row_end + 1):
             band_max_y = grid_bbox[3] - row * metatile_span
             band_min_y = band_max_y - metatile_span
@@ -1622,12 +1622,40 @@ class TileGeneration:
                 if interval is not None:
                     intervals.append(interval)
 
-            for start, end in self._merge_index_intervals(intervals):
-                for x_index in range(start, end + 1):
-                    metatilecoords.append(TileCoord(zoom, x_index * meta_size, row * meta_size, meta_size))
+            merged_intervals = self._merge_index_intervals(intervals)
+            if merged_intervals:
+                row_intervals.append((row, merged_intervals))
 
-        self.meta_tilecoords_sparse_cache[cache_key] = metatilecoords
-        return metatilecoords
+        self.meta_tilecoords_sparse_cache[cache_key] = row_intervals
+        return row_intervals
+
+    def _get_sparse_metatilecoords(
+        self,
+        config: DatedConfig,
+        layer_name: str,
+        grid_name: str,
+        grid: tilecloud_chain.configuration.Grid,
+        geometry: BaseGeometry,
+        zoom: int,
+        resolution: int | float,
+        meta_size: int,
+        px_buffer: int | float,
+    ) -> Iterable[TileCoord]:
+        row_intervals = self._get_sparse_metatile_intervals(
+            config,
+            layer_name,
+            grid_name,
+            grid,
+            geometry,
+            zoom,
+            resolution,
+            meta_size,
+            px_buffer,
+        )
+        for row, intervals in row_intervals:
+            for start, end in intervals:
+                for x_index in range(start, end + 1):
+                    yield TileCoord(zoom, x_index * meta_size, row * meta_size, meta_size)
 
     def init_tilecoords(
         self,
@@ -1702,10 +1730,10 @@ class TileGeneration:
             if sparse_meta_seed and layer["meta"]:
                 meta_size = layer.get("meta_size", configuration.LAYER_META_SIZE_DEFAULT)
                 px_buffer = layer.get("px_buffer", configuration.LAYER_PIXEL_BUFFER_DEFAULT)
-                metatilecoords: list[TileCoord] = []
+                metatilecoord_iterables: list[Iterable[TileCoord]] = []
                 for zoom in self.options.zoom:
                     if zoom in geoms:
-                        metatilecoords.extend(
+                        metatilecoord_iterables.append(
                             self._get_sparse_metatilecoords(
                                 config,
                                 layer_name,
@@ -1718,7 +1746,7 @@ class TileGeneration:
                                 px_buffer,
                             ),
                         )
-                grid_tilecoords[grid_name] = metatilecoords
+                grid_tilecoords[grid_name] = chain.from_iterable(metatilecoord_iterables)
                 continue
 
             # Fill the bounding pyramid

--- a/tilecloud_chain/__init__.py
+++ b/tilecloud_chain/__init__.py
@@ -419,7 +419,7 @@ class SparseMetaTileBoundingPyramid(BoundingPyramid):
         geoms: dict[str | int, BaseGeometry],
         zooms: Iterable[int],
         resolutions: list[int | float],
-        px_buffer: int | float,
+        px_buffer: float,
     ) -> None:
         super().__init__(tilegrid=tilegrid)
         self._grid = grid
@@ -814,6 +814,7 @@ class TileGeneration:
         self.multi_task = multi_task
         self.configs: dict[Path, DatedConfig] = {}
         self.hosts_cache: DatedHosts | None = None
+
         class Options(NamedTuple):
             verbose: bool
             debug: bool
@@ -1618,6 +1619,7 @@ class TileGeneration:
             config.mtime,
         )
         return geoms
+
     def init_tilecoords(
         self,
         config: DatedConfig,

--- a/tilecloud_chain/__init__.py
+++ b/tilecloud_chain/__init__.py
@@ -1552,7 +1552,7 @@ class TileGeneration:
         zoom: int,
         resolution: float,
         meta_size: int,
-        px_buffer: int | float,
+        px_buffer: float,
     ) -> list[tuple[int, list[tuple[int, int]]]]:
         cache_key = (
             str(config.file),
@@ -1637,9 +1637,9 @@ class TileGeneration:
         grid: tilecloud_chain.configuration.Grid,
         geometry: BaseGeometry,
         zoom: int,
-        resolution: int | float,
+        resolution: float,
         meta_size: int,
-        px_buffer: int | float,
+        px_buffer: float,
     ) -> Iterable[TileCoord]:
         row_intervals = self._get_sparse_metatile_intervals(
             config,

--- a/tilecloud_chain/__init__.py
+++ b/tilecloud_chain/__init__.py
@@ -40,6 +40,7 @@ from c2cwsgiutils import sentry
 from PIL import Image
 from prometheus_client import Counter, Summary
 from ruamel.yaml import YAML
+from shapely.geometry import box
 from shapely.geometry.base import BaseGeometry
 from shapely.geometry.polygon import Polygon
 from shapely.ops import unary_union
@@ -672,6 +673,10 @@ class TileGeneration:
         self.multi_task = multi_task
         self.configs: dict[Path, DatedConfig] = {}
         self.hosts_cache: DatedHosts | None = None
+        self.meta_tilecoords_sparse_cache: dict[
+            tuple[str, float, str, str, int, int, float, float],
+            list[TileCoord],
+        ] = {}
 
         class Options(NamedTuple):
             verbose: bool
@@ -1478,7 +1483,159 @@ class TileGeneration:
         )
         return geoms
 
-    def init_tilecoords(self, config: DatedConfig, layer_name: str, used_grid_name: str | None) -> None:
+    @staticmethod
+    def _bounds_to_index_range(
+        bounds_min: float,
+        bounds_max: float,
+        origin: float,
+        span: float,
+        max_index: int,
+    ) -> tuple[int, int] | None:
+        if bounds_min > bounds_max:
+            bounds_min, bounds_max = bounds_max, bounds_min
+        start = math.floor((bounds_min - origin) / span)
+        end = math.ceil((bounds_max - origin) / span) - 1
+        start = max(0, min(max_index, start))
+        end = max(0, min(max_index, end))
+        if start > end:
+            return None
+        return start, end
+
+    @staticmethod
+    def _y_bounds_to_index_range(
+        bounds_min: float,
+        bounds_max: float,
+        origin_top: float,
+        span: float,
+        max_index: int,
+    ) -> tuple[int, int] | None:
+        if bounds_min > bounds_max:
+            bounds_min, bounds_max = bounds_max, bounds_min
+        start = math.floor((origin_top - bounds_max) / span)
+        end = math.ceil((origin_top - bounds_min) / span) - 1
+        start = max(0, min(max_index, start))
+        end = max(0, min(max_index, end))
+        if start > end:
+            return None
+        return start, end
+
+    @staticmethod
+    def _merge_index_intervals(intervals: Iterable[tuple[int, int]]) -> list[tuple[int, int]]:
+        sorted_intervals = sorted(intervals, key=lambda interval: (interval[0], interval[1]))
+        if not sorted_intervals:
+            return []
+        merged_intervals = [sorted_intervals[0]]
+        for start, end in sorted_intervals[1:]:
+            previous_start, previous_end = merged_intervals[-1]
+            if start <= previous_end + 1:
+                merged_intervals[-1] = (previous_start, max(previous_end, end))
+            else:
+                merged_intervals.append((start, end))
+        return merged_intervals
+
+    @staticmethod
+    def _iter_leaf_geometries(geometry: BaseGeometry) -> Iterable[BaseGeometry]:
+        geometries = getattr(geometry, "geoms", None)
+        if geometries is None:
+            yield geometry
+            return
+        for sub_geometry in geometries:
+            yield from TileGeneration._iter_leaf_geometries(sub_geometry)
+
+    def _get_sparse_metatilecoords(
+        self,
+        config: DatedConfig,
+        layer_name: str,
+        grid_name: str,
+        grid: tilecloud_chain.configuration.Grid,
+        geometry: BaseGeometry,
+        zoom: int,
+        resolution: int | float,
+        meta_size: int,
+        px_buffer: int | float,
+    ) -> list[TileCoord]:
+        cache_key = (
+            str(config.file),
+            config.mtime,
+            layer_name,
+            grid_name,
+            zoom,
+            meta_size,
+            float(px_buffer),
+            float(resolution),
+        )
+        if cache_key in self.meta_tilecoords_sparse_cache:
+            return self.meta_tilecoords_sparse_cache[cache_key]
+
+        tile_size = float(grid.get("tile_size", configuration.TILE_SIZE_DEFAULT))
+        metatile_span = tile_size * float(resolution) * meta_size
+        grid_bbox = [float(v) for v in grid["bbox"]]
+
+        matrix_width = math.ceil((grid_bbox[2] - grid_bbox[0]) / metatile_span)
+        matrix_height = math.ceil((grid_bbox[3] - grid_bbox[1]) / metatile_span)
+        max_x_index = matrix_width - 1
+        max_y_index = matrix_height - 1
+
+        geom = geometry
+        m_buffer = float(px_buffer) * float(resolution)
+        if m_buffer != 0:
+            geom = geom.buffer(m_buffer, 1)
+
+        if geom.is_empty:
+            self.meta_tilecoords_sparse_cache[cache_key] = []
+            return []
+
+        minx, miny, maxx, maxy = geom.bounds
+        if len([value for value in (minx, miny, maxx, maxy) if not math.isnan(value)]) == 0:
+            _LOGGER.warning("bounds empty for zoom %s", zoom)
+            self.meta_tilecoords_sparse_cache[cache_key] = []
+            return []
+
+        row_range = self._y_bounds_to_index_range(miny, maxy, grid_bbox[3], metatile_span, max_y_index)
+        if row_range is None:
+            self.meta_tilecoords_sparse_cache[cache_key] = []
+            return []
+
+        row_start, row_end = row_range
+        metatilecoords: list[TileCoord] = []
+        for row in range(row_start, row_end + 1):
+            band_max_y = grid_bbox[3] - row * metatile_span
+            band_min_y = band_max_y - metatile_span
+            row_geom = geom.intersection(box(grid_bbox[0], band_min_y, grid_bbox[2], band_max_y))
+            if row_geom.is_empty:
+                continue
+
+            intervals: list[tuple[int, int]] = []
+            for sub_geometry in self._iter_leaf_geometries(row_geom):
+                if sub_geometry.is_empty:
+                    continue
+                sub_minx, _, sub_maxx, _ = sub_geometry.bounds
+                if math.isnan(sub_minx) or math.isnan(sub_maxx):
+                    continue
+                interval = self._bounds_to_index_range(
+                    sub_minx,
+                    sub_maxx,
+                    grid_bbox[0],
+                    metatile_span,
+                    max_x_index,
+                )
+                if interval is not None:
+                    intervals.append(interval)
+
+            for start, end in self._merge_index_intervals(intervals):
+                for x_index in range(start, end + 1):
+                    metatilecoords.append(TileCoord(zoom, x_index * meta_size, row * meta_size, meta_size))
+
+        self.meta_tilecoords_sparse_cache[cache_key] = metatilecoords
+        return metatilecoords
+
+    def init_tilecoords(
+        self,
+        config: DatedConfig,
+        layer_name: str,
+        used_grid_name: str | None,
+        sparse_meta_seed: bool = False,
+    ) -> None:
         """Initialize the tilestream for the given layer."""
         if layer_name not in config.config.get("layers", {}):
             _LOGGER.warning("Layer %s not found in config %s", layer_name, config.file)
@@ -1540,10 +1697,33 @@ class TileGeneration:
             if self.options.zoom is None:
                 self.options.zoom = [z for z, r in enumerate(resolutions)]
 
+            geoms = self.get_geoms(config, layer_name, grid_name)
+
+            if sparse_meta_seed and layer["meta"]:
+                meta_size = layer.get("meta_size", configuration.LAYER_META_SIZE_DEFAULT)
+                px_buffer = layer.get("px_buffer", configuration.LAYER_PIXEL_BUFFER_DEFAULT)
+                metatilecoords: list[TileCoord] = []
+                for zoom in self.options.zoom:
+                    if zoom in geoms:
+                        metatilecoords.extend(
+                            self._get_sparse_metatilecoords(
+                                config,
+                                layer_name,
+                                grid_name,
+                                grid,
+                                geoms[zoom],
+                                zoom,
+                                resolutions[zoom],
+                                meta_size,
+                                px_buffer,
+                            ),
+                        )
+                grid_tilecoords[grid_name] = metatilecoords
+                continue
+
             # Fill the bounding pyramid
             tilegrid = self.get_grid(config, get_grid_name(config, layer_name, grid_name))
             bounding_pyramid = BoundingPyramid(tilegrid=tilegrid)
-            geoms = self.get_geoms(config, layer_name, grid_name)
             for zoom in self.options.zoom:
                 if zoom in geoms:
                     extent = geoms[zoom].bounds

--- a/tilecloud_chain/__init__.py
+++ b/tilecloud_chain/__init__.py
@@ -16,7 +16,7 @@ import sys
 import tempfile
 import time
 from argparse import ArgumentParser, Namespace
-from collections.abc import AsyncIterator, Awaitable, Callable, Iterable
+from collections.abc import AsyncIterator, Awaitable, Callable, Iterable, Iterator
 from dataclasses import dataclass
 from fractions import Fraction
 from hashlib import sha1
@@ -415,7 +415,7 @@ class SparseMetaTileBoundingPyramid(BoundingPyramid):
     def __init__(
         self,
         tilegrid: TileGrid,
-        grid: dict[str, Any],
+        grid: tilecloud_chain.configuration.Grid,
         geoms: dict[str | int, BaseGeometry],
         zooms: Iterable[int],
         resolutions: list[int | float],
@@ -487,7 +487,7 @@ class SparseMetaTileBoundingPyramid(BoundingPyramid):
         for sub_geometry in geometries:
             yield from SparseMetaTileBoundingPyramid._iter_leaf_geometries(sub_geometry)
 
-    def metatilecoords(self, meta_size: int) -> Iterable[TileCoord]:
+    def metatilecoords(self, n: int = 8) -> Iterator[TileCoord]:
         """Yield sparse metatile coordinates lazily for configured zoom levels."""
         tile_size = float(self._grid.get("tile_size", configuration.TILE_SIZE_DEFAULT))
         grid_bbox = [float(v) for v in self._grid["bbox"]]
@@ -498,7 +498,7 @@ class SparseMetaTileBoundingPyramid(BoundingPyramid):
                 continue
 
             resolution = float(self._resolutions[zoom])
-            metatile_span = tile_size * resolution * meta_size
+            metatile_span = tile_size * resolution * n
             matrix_width = math.ceil((grid_bbox[2] - grid_bbox[0]) / metatile_span)
             matrix_height = math.ceil((grid_bbox[3] - grid_bbox[1]) / metatile_span)
             max_x_index = matrix_width - 1
@@ -548,7 +548,7 @@ class SparseMetaTileBoundingPyramid(BoundingPyramid):
 
                 for start, end in self._merge_index_intervals(intervals):
                     for x_index in range(start, end + 1):
-                        yield TileCoord(zoom, x_index * meta_size, row * meta_size, meta_size)
+                        yield TileCoord(zoom, x_index * n, row * n, n)
 
 
 class MissingErrorFileError(Exception):

--- a/tilecloud_chain/__init__.py
+++ b/tilecloud_chain/__init__.py
@@ -1550,9 +1550,9 @@ class TileGeneration:
         grid: tilecloud_chain.configuration.Grid,
         geometry: BaseGeometry,
         zoom: int,
-        resolution: int | float,
+        resolution: float,
         meta_size: int,
-        px_buffer: int | float,
+        px_buffer: float,
     ) -> list[TileCoord]:
         cache_key = (
             str(config.file),

--- a/tilecloud_chain/__init__.py
+++ b/tilecloud_chain/__init__.py
@@ -21,7 +21,7 @@ from dataclasses import dataclass
 from fractions import Fraction
 from hashlib import sha1
 from io import BytesIO
-from itertools import chain, product
+from itertools import product
 from math import ceil, sqrt
 from typing import IO, TYPE_CHECKING, Any, Literal, NamedTuple, TextIO, TypedDict, cast
 
@@ -409,6 +409,147 @@ class DatedHosts:
         self.mtime = mtime
 
 
+class SparseMetaTileBoundingPyramid(BoundingPyramid):
+    """Bounding pyramid variant that computes sparse metatiles lazily."""
+
+    def __init__(
+        self,
+        tilegrid: TileGrid,
+        grid: dict[str, Any],
+        geoms: dict[str | int, BaseGeometry],
+        zooms: Iterable[int],
+        resolutions: list[int | float],
+        px_buffer: int | float,
+    ) -> None:
+        super().__init__(tilegrid=tilegrid)
+        self._grid = grid
+        self._geoms = geoms
+        self._zooms = tuple(zooms)
+        self._resolutions = resolutions
+        self._px_buffer = float(px_buffer)
+
+    @staticmethod
+    def _bounds_to_index_range(
+        bounds_min: float,
+        bounds_max: float,
+        origin: float,
+        span: float,
+        max_index: int,
+    ) -> tuple[int, int] | None:
+        if bounds_min > bounds_max:
+            bounds_min, bounds_max = bounds_max, bounds_min
+        start = math.floor((bounds_min - origin) / span)
+        end = math.ceil((bounds_max - origin) / span) - 1
+        start = max(0, min(max_index, start))
+        end = max(0, min(max_index, end))
+        if start > end:
+            return None
+        return start, end
+
+    @staticmethod
+    def _y_bounds_to_index_range(
+        bounds_min: float,
+        bounds_max: float,
+        origin_top: float,
+        span: float,
+        max_index: int,
+    ) -> tuple[int, int] | None:
+        if bounds_min > bounds_max:
+            bounds_min, bounds_max = bounds_max, bounds_min
+        start = math.floor((origin_top - bounds_max) / span)
+        end = math.ceil((origin_top - bounds_min) / span) - 1
+        start = max(0, min(max_index, start))
+        end = max(0, min(max_index, end))
+        if start > end:
+            return None
+        return start, end
+
+    @staticmethod
+    def _merge_index_intervals(intervals: Iterable[tuple[int, int]]) -> list[tuple[int, int]]:
+        sorted_intervals = sorted(intervals, key=lambda interval: (interval[0], interval[1]))
+        if not sorted_intervals:
+            return []
+        merged_intervals = [sorted_intervals[0]]
+        for start, end in sorted_intervals[1:]:
+            previous_start, previous_end = merged_intervals[-1]
+            if start <= previous_end + 1:
+                merged_intervals[-1] = (previous_start, max(previous_end, end))
+            else:
+                merged_intervals.append((start, end))
+        return merged_intervals
+
+    @staticmethod
+    def _iter_leaf_geometries(geometry: BaseGeometry) -> Iterable[BaseGeometry]:
+        geometries = getattr(geometry, "geoms", None)
+        if geometries is None:
+            yield geometry
+            return
+        for sub_geometry in geometries:
+            yield from SparseMetaTileBoundingPyramid._iter_leaf_geometries(sub_geometry)
+
+    def metatilecoords(self, meta_size: int) -> Iterable[TileCoord]:
+        tile_size = float(self._grid.get("tile_size", configuration.TILE_SIZE_DEFAULT))
+        grid_bbox = [float(v) for v in self._grid["bbox"]]
+
+        for zoom in self._zooms:
+            geom = self._geoms.get(zoom)
+            if geom is None:
+                continue
+
+            resolution = float(self._resolutions[zoom])
+            metatile_span = tile_size * resolution * meta_size
+            matrix_width = math.ceil((grid_bbox[2] - grid_bbox[0]) / metatile_span)
+            matrix_height = math.ceil((grid_bbox[3] - grid_bbox[1]) / metatile_span)
+            max_x_index = matrix_width - 1
+            max_y_index = matrix_height - 1
+
+            buffered_geom = geom
+            m_buffer = self._px_buffer * resolution
+            if m_buffer != 0:
+                buffered_geom = buffered_geom.buffer(m_buffer, 1)
+
+            if buffered_geom.is_empty:
+                continue
+
+            minx, miny, maxx, maxy = buffered_geom.bounds
+            if all(math.isnan(value) for value in (minx, miny, maxx, maxy)):
+                _LOGGER.warning("bounds empty for zoom %s", zoom)
+                continue
+
+            row_range = self._y_bounds_to_index_range(miny, maxy, grid_bbox[3], metatile_span, max_y_index)
+            if row_range is None:
+                continue
+
+            row_start, row_end = row_range
+            for row in range(row_start, row_end + 1):
+                band_max_y = grid_bbox[3] - row * metatile_span
+                band_min_y = band_max_y - metatile_span
+                row_geom = buffered_geom.intersection(box(grid_bbox[0], band_min_y, grid_bbox[2], band_max_y))
+                if row_geom.is_empty:
+                    continue
+
+                intervals: list[tuple[int, int]] = []
+                for sub_geometry in self._iter_leaf_geometries(row_geom):
+                    if sub_geometry.is_empty:
+                        continue
+                    sub_minx, _, sub_maxx, _ = sub_geometry.bounds
+                    if math.isnan(sub_minx) or math.isnan(sub_maxx):
+                        continue
+                    interval = self._bounds_to_index_range(
+                        sub_minx,
+                        sub_maxx,
+                        grid_bbox[0],
+                        metatile_span,
+                        max_x_index,
+                    )
+                    if interval is not None:
+                        intervals.append(interval)
+
+                for start, end in self._merge_index_intervals(intervals):
+                    for x_index in range(start, end + 1):
+                        yield TileCoord(zoom, x_index * meta_size, row * meta_size, meta_size)
+
+
 class MissingErrorFileError(Exception):
     """Missing error file exception."""
 
@@ -673,11 +814,6 @@ class TileGeneration:
         self.multi_task = multi_task
         self.configs: dict[Path, DatedConfig] = {}
         self.hosts_cache: DatedHosts | None = None
-        self.meta_tilecoords_sparse_cache: dict[
-            tuple[str, float, str, str, int, int, float, float],
-            list[tuple[int, list[tuple[int, int]]]],
-        ] = {}
-
         class Options(NamedTuple):
             verbose: bool
             debug: bool
@@ -1482,181 +1618,6 @@ class TileGeneration:
             config.mtime,
         )
         return geoms
-
-    @staticmethod
-    def _bounds_to_index_range(
-        bounds_min: float,
-        bounds_max: float,
-        origin: float,
-        span: float,
-        max_index: int,
-    ) -> tuple[int, int] | None:
-        if bounds_min > bounds_max:
-            bounds_min, bounds_max = bounds_max, bounds_min
-        start = math.floor((bounds_min - origin) / span)
-        end = math.ceil((bounds_max - origin) / span) - 1
-        start = max(0, min(max_index, start))
-        end = max(0, min(max_index, end))
-        if start > end:
-            return None
-        return start, end
-
-    @staticmethod
-    def _y_bounds_to_index_range(
-        bounds_min: float,
-        bounds_max: float,
-        origin_top: float,
-        span: float,
-        max_index: int,
-    ) -> tuple[int, int] | None:
-        if bounds_min > bounds_max:
-            bounds_min, bounds_max = bounds_max, bounds_min
-        start = math.floor((origin_top - bounds_max) / span)
-        end = math.ceil((origin_top - bounds_min) / span) - 1
-        start = max(0, min(max_index, start))
-        end = max(0, min(max_index, end))
-        if start > end:
-            return None
-        return start, end
-
-    @staticmethod
-    def _merge_index_intervals(intervals: Iterable[tuple[int, int]]) -> list[tuple[int, int]]:
-        sorted_intervals = sorted(intervals, key=lambda interval: (interval[0], interval[1]))
-        if not sorted_intervals:
-            return []
-        merged_intervals = [sorted_intervals[0]]
-        for start, end in sorted_intervals[1:]:
-            previous_start, previous_end = merged_intervals[-1]
-            if start <= previous_end + 1:
-                merged_intervals[-1] = (previous_start, max(previous_end, end))
-            else:
-                merged_intervals.append((start, end))
-        return merged_intervals
-
-    @staticmethod
-    def _iter_leaf_geometries(geometry: BaseGeometry) -> Iterable[BaseGeometry]:
-        geometries = getattr(geometry, "geoms", None)
-        if geometries is None:
-            yield geometry
-            return
-        for sub_geometry in geometries:
-            yield from TileGeneration._iter_leaf_geometries(sub_geometry)
-
-    def _get_sparse_metatile_intervals(
-        self,
-        config: DatedConfig,
-        layer_name: str,
-        grid_name: str,
-        grid: tilecloud_chain.configuration.Grid,
-        geometry: BaseGeometry,
-        zoom: int,
-        resolution: float,
-        meta_size: int,
-        px_buffer: float,
-    ) -> list[tuple[int, list[tuple[int, int]]]]:
-        cache_key = (
-            str(config.file),
-            config.mtime,
-            layer_name,
-            grid_name,
-            zoom,
-            meta_size,
-            float(px_buffer),
-            float(resolution),
-        )
-        if cache_key in self.meta_tilecoords_sparse_cache:
-            return self.meta_tilecoords_sparse_cache[cache_key]
-
-        tile_size = float(grid.get("tile_size", configuration.TILE_SIZE_DEFAULT))
-        metatile_span = tile_size * float(resolution) * meta_size
-        grid_bbox = [float(v) for v in grid["bbox"]]
-
-        matrix_width = math.ceil((grid_bbox[2] - grid_bbox[0]) / metatile_span)
-        matrix_height = math.ceil((grid_bbox[3] - grid_bbox[1]) / metatile_span)
-        max_x_index = matrix_width - 1
-        max_y_index = matrix_height - 1
-
-        geom = geometry
-        m_buffer = float(px_buffer) * float(resolution)
-        if m_buffer != 0:
-            geom = geom.buffer(m_buffer, 1)
-
-        if geom.is_empty:
-            self.meta_tilecoords_sparse_cache[cache_key] = []
-            return []
-
-        minx, miny, maxx, maxy = geom.bounds
-        if len([value for value in (minx, miny, maxx, maxy) if not math.isnan(value)]) == 0:
-            _LOGGER.warning("bounds empty for zoom %s", zoom)
-            self.meta_tilecoords_sparse_cache[cache_key] = []
-            return []
-
-        row_range = self._y_bounds_to_index_range(miny, maxy, grid_bbox[3], metatile_span, max_y_index)
-        if row_range is None:
-            self.meta_tilecoords_sparse_cache[cache_key] = []
-            return []
-
-        row_start, row_end = row_range
-        row_intervals: list[tuple[int, list[tuple[int, int]]]] = []
-        for row in range(row_start, row_end + 1):
-            band_max_y = grid_bbox[3] - row * metatile_span
-            band_min_y = band_max_y - metatile_span
-            row_geom = geom.intersection(box(grid_bbox[0], band_min_y, grid_bbox[2], band_max_y))
-            if row_geom.is_empty:
-                continue
-
-            intervals: list[tuple[int, int]] = []
-            for sub_geometry in self._iter_leaf_geometries(row_geom):
-                if sub_geometry.is_empty:
-                    continue
-                sub_minx, _, sub_maxx, _ = sub_geometry.bounds
-                if math.isnan(sub_minx) or math.isnan(sub_maxx):
-                    continue
-                interval = self._bounds_to_index_range(
-                    sub_minx,
-                    sub_maxx,
-                    grid_bbox[0],
-                    metatile_span,
-                    max_x_index,
-                )
-                if interval is not None:
-                    intervals.append(interval)
-
-            merged_intervals = self._merge_index_intervals(intervals)
-            if merged_intervals:
-                row_intervals.append((row, merged_intervals))
-
-        self.meta_tilecoords_sparse_cache[cache_key] = row_intervals
-        return row_intervals
-
-    def _get_sparse_metatilecoords(
-        self,
-        config: DatedConfig,
-        layer_name: str,
-        grid_name: str,
-        grid: tilecloud_chain.configuration.Grid,
-        geometry: BaseGeometry,
-        zoom: int,
-        resolution: float,
-        meta_size: int,
-        px_buffer: float,
-    ) -> Iterable[TileCoord]:
-        row_intervals = self._get_sparse_metatile_intervals(
-            config,
-            layer_name,
-            grid_name,
-            grid,
-            geometry,
-            zoom,
-            resolution,
-            meta_size,
-            px_buffer,
-        )
-        for row, intervals in row_intervals:
-            for start, end in intervals:
-                for x_index in range(start, end + 1):
-                    yield TileCoord(zoom, x_index * meta_size, row * meta_size, meta_size)
-
     def init_tilecoords(
         self,
         config: DatedConfig,
@@ -1730,23 +1691,16 @@ class TileGeneration:
             if sparse_meta_seed and layer["meta"]:
                 meta_size = layer.get("meta_size", configuration.LAYER_META_SIZE_DEFAULT)
                 px_buffer = layer.get("px_buffer", configuration.LAYER_PIXEL_BUFFER_DEFAULT)
-                metatilecoord_iterables: list[Iterable[TileCoord]] = []
-                for zoom in self.options.zoom:
-                    if zoom in geoms:
-                        metatilecoord_iterables.append(
-                            self._get_sparse_metatilecoords(
-                                config,
-                                layer_name,
-                                grid_name,
-                                grid,
-                                geoms[zoom],
-                                zoom,
-                                resolutions[zoom],
-                                meta_size,
-                                px_buffer,
-                            ),
-                        )
-                grid_tilecoords[grid_name] = chain.from_iterable(metatilecoord_iterables)
+                tilegrid = self.get_grid(config, get_grid_name(config, layer_name, grid_name))
+                sparse_bounding_pyramid = SparseMetaTileBoundingPyramid(
+                    tilegrid=tilegrid,
+                    grid=grid,
+                    geoms=geoms,
+                    zooms=self.options.zoom,
+                    resolutions=resolutions,
+                    px_buffer=px_buffer,
+                )
+                grid_tilecoords[grid_name] = sparse_bounding_pyramid.metatilecoords(meta_size)
                 continue
 
             # Fill the bounding pyramid

--- a/tilecloud_chain/__init__.py
+++ b/tilecloud_chain/__init__.py
@@ -488,6 +488,7 @@ class SparseMetaTileBoundingPyramid(BoundingPyramid):
             yield from SparseMetaTileBoundingPyramid._iter_leaf_geometries(sub_geometry)
 
     def metatilecoords(self, meta_size: int) -> Iterable[TileCoord]:
+        """Yield sparse metatile coordinates lazily for configured zoom levels."""
         tile_size = float(self._grid.get("tile_size", configuration.TILE_SIZE_DEFAULT))
         grid_bbox = [float(v) for v in self._grid["bbox"]]
 

--- a/tilecloud_chain/__init__.py
+++ b/tilecloud_chain/__init__.py
@@ -1712,7 +1712,9 @@ class TileGeneration:
             return
         min_resolution_seed = layer["min_resolution_seed"]
         if self.options.zoom is None:
-            self.options.zoom = [z for z, resolution in enumerate(resolutions) if resolution >= min_resolution_seed]
+            self.options.zoom = [
+                z for z, resolution in enumerate(resolutions) if resolution >= min_resolution_seed
+            ]
             return
         for zoom in self.options.zoom:
             resolution = resolutions[zoom]
@@ -1810,7 +1812,9 @@ class TileGeneration:
                 ),
             )
         if layer["meta"]:
-            return bounding_pyramid.metatilecoords(layer.get("meta_size", configuration.LAYER_META_SIZE_DEFAULT))
+            return bounding_pyramid.metatilecoords(
+                layer.get("meta_size", configuration.LAYER_META_SIZE_DEFAULT)
+            )
         return bounding_pyramid
 
     def init_tilecoords(

--- a/tilecloud_chain/__init__.py
+++ b/tilecloud_chain/__init__.py
@@ -487,68 +487,117 @@ class SparseMetaTileBoundingPyramid(BoundingPyramid):
         for sub_geometry in geometries:
             yield from SparseMetaTileBoundingPyramid._iter_leaf_geometries(sub_geometry)
 
+    @staticmethod
+    def _has_only_nan_bounds(bounds: tuple[float, float, float, float]) -> bool:
+        return all(math.isnan(value) for value in bounds)
+
+    def _get_zoom_context(
+        self,
+        zoom: int,
+        n: int,
+        tile_size: float,
+        grid_bbox: list[float],
+    ) -> tuple[BaseGeometry, float, int, int] | None:
+        geom = self._geoms.get(zoom)
+        if geom is None:
+            return None
+
+        resolution = float(self._resolutions[zoom])
+        metatile_span = tile_size * resolution * n
+        matrix_width = math.ceil((grid_bbox[2] - grid_bbox[0]) / metatile_span)
+        matrix_height = math.ceil((grid_bbox[3] - grid_bbox[1]) / metatile_span)
+
+        buffered_geom = geom
+        m_buffer = self._px_buffer * resolution
+        if m_buffer != 0:
+            buffered_geom = buffered_geom.buffer(m_buffer, 1)
+
+        if buffered_geom.is_empty:
+            return None
+        if self._has_only_nan_bounds(buffered_geom.bounds):
+            _LOGGER.warning("bounds empty for zoom %s", zoom)
+            return None
+
+        return buffered_geom, metatile_span, matrix_width - 1, matrix_height - 1
+
+    def _collect_row_intervals(
+        self,
+        row_geom: BaseGeometry,
+        grid_bbox: list[float],
+        metatile_span: float,
+        max_x_index: int,
+    ) -> list[tuple[int, int]]:
+        intervals: list[tuple[int, int]] = []
+        for sub_geometry in self._iter_leaf_geometries(row_geom):
+            if sub_geometry.is_empty:
+                continue
+            sub_minx, _, sub_maxx, _ = sub_geometry.bounds
+            if math.isnan(sub_minx) or math.isnan(sub_maxx):
+                continue
+            interval = self._bounds_to_index_range(
+                sub_minx,
+                sub_maxx,
+                grid_bbox[0],
+                metatile_span,
+                max_x_index,
+            )
+            if interval is not None:
+                intervals.append(interval)
+        return self._merge_index_intervals(intervals)
+
+    def _iter_row_tilecoords(
+        self,
+        zoom: int,
+        n: int,
+        buffered_geom: BaseGeometry,
+        grid_bbox: list[float],
+        metatile_span: float,
+        max_x_index: int,
+        row_range: tuple[int, int],
+    ) -> Iterator[TileCoord]:
+        row_start, row_end = row_range
+        for row in range(row_start, row_end + 1):
+            band_max_y = grid_bbox[3] - row * metatile_span
+            band_min_y = band_max_y - metatile_span
+            row_geom = buffered_geom.intersection(box(grid_bbox[0], band_min_y, grid_bbox[2], band_max_y))
+            if row_geom.is_empty:
+                continue
+            for start, end in self._collect_row_intervals(
+                row_geom,
+                grid_bbox,
+                metatile_span,
+                max_x_index,
+            ):
+                yield from self._iter_interval_tilecoords(zoom, n, row, start, end)
+
+    @staticmethod
+    def _iter_interval_tilecoords(zoom: int, n: int, row: int, start: int, end: int) -> Iterator[TileCoord]:
+        for x_index in range(start, end + 1):
+            yield TileCoord(zoom, x_index * n, row * n, n)
+
     def metatilecoords(self, n: int = 8) -> Iterator[TileCoord]:
         """Yield sparse metatile coordinates lazily for configured zoom levels."""
         tile_size = float(self._grid.get("tile_size", configuration.TILE_SIZE_DEFAULT))
         grid_bbox = [float(v) for v in self._grid["bbox"]]
 
         for zoom in self._zooms:
-            geom = self._geoms.get(zoom)
-            if geom is None:
+            zoom_context = self._get_zoom_context(zoom, n, tile_size, grid_bbox)
+            if zoom_context is None:
                 continue
-
-            resolution = float(self._resolutions[zoom])
-            metatile_span = tile_size * resolution * n
-            matrix_width = math.ceil((grid_bbox[2] - grid_bbox[0]) / metatile_span)
-            matrix_height = math.ceil((grid_bbox[3] - grid_bbox[1]) / metatile_span)
-            max_x_index = matrix_width - 1
-            max_y_index = matrix_height - 1
-
-            buffered_geom = geom
-            m_buffer = self._px_buffer * resolution
-            if m_buffer != 0:
-                buffered_geom = buffered_geom.buffer(m_buffer, 1)
-
-            if buffered_geom.is_empty:
-                continue
-
-            minx, miny, maxx, maxy = buffered_geom.bounds
-            if all(math.isnan(value) for value in (minx, miny, maxx, maxy)):
-                _LOGGER.warning("bounds empty for zoom %s", zoom)
-                continue
-
+            buffered_geom, metatile_span, max_x_index, max_y_index = zoom_context
+            _, miny, _, maxy = buffered_geom.bounds
             row_range = self._y_bounds_to_index_range(miny, maxy, grid_bbox[3], metatile_span, max_y_index)
             if row_range is None:
                 continue
-
-            row_start, row_end = row_range
-            for row in range(row_start, row_end + 1):
-                band_max_y = grid_bbox[3] - row * metatile_span
-                band_min_y = band_max_y - metatile_span
-                row_geom = buffered_geom.intersection(box(grid_bbox[0], band_min_y, grid_bbox[2], band_max_y))
-                if row_geom.is_empty:
-                    continue
-
-                intervals: list[tuple[int, int]] = []
-                for sub_geometry in self._iter_leaf_geometries(row_geom):
-                    if sub_geometry.is_empty:
-                        continue
-                    sub_minx, _, sub_maxx, _ = sub_geometry.bounds
-                    if math.isnan(sub_minx) or math.isnan(sub_maxx):
-                        continue
-                    interval = self._bounds_to_index_range(
-                        sub_minx,
-                        sub_maxx,
-                        grid_bbox[0],
-                        metatile_span,
-                        max_x_index,
-                    )
-                    if interval is not None:
-                        intervals.append(interval)
-
-                for start, end in self._merge_index_intervals(intervals):
-                    for x_index in range(start, end + 1):
-                        yield TileCoord(zoom, x_index * n, row * n, n)
+            yield from self._iter_row_tilecoords(
+                zoom,
+                n,
+                buffered_geom,
+                grid_bbox,
+                metatile_span,
+                max_x_index,
+                row_range,
+            )
 
 
 class MissingErrorFileError(Exception):
@@ -1621,6 +1670,149 @@ class TileGeneration:
         )
         return geoms
 
+    def _set_default_zoom_for_time(
+        self,
+        layer: tilecloud_chain.configuration.Layer,
+        resolutions: list[int | float],
+    ) -> None:
+        if self.options.time is None or self.options.zoom is not None:
+            return
+        if "min_resolution_seed" in layer:
+            self.options.zoom = [resolutions.index(layer["min_resolution_seed"])]
+        else:
+            self.options.zoom = [len(resolutions) - 1]
+
+    def _filter_zoom_outside_grid(
+        self,
+        resolutions: list[int | float],
+        grid_name: str,
+        layer_name: str,
+    ) -> None:
+        if self.options.zoom is None:
+            return
+        zoom_max = len(resolutions) - 1
+        for zoom in self.options.zoom:
+            if zoom > zoom_max:
+                _LOGGER.warning(
+                    "zoom %i is greater than the maximum zoom %i of grid %s of layer %s, ignored.",
+                    zoom,
+                    zoom_max,
+                    grid_name,
+                    layer_name,
+                )
+        self.options.zoom = [z for z in self.options.zoom if z <= zoom_max]
+
+    def _apply_min_resolution_seed_filter(
+        self,
+        layer: tilecloud_chain.configuration.Layer,
+        resolutions: list[int | float],
+        layer_name: str,
+    ) -> None:
+        if "min_resolution_seed" not in layer:
+            return
+        min_resolution_seed = layer["min_resolution_seed"]
+        if self.options.zoom is None:
+            self.options.zoom = [z for z, resolution in enumerate(resolutions) if resolution >= min_resolution_seed]
+            return
+        for zoom in self.options.zoom:
+            resolution = resolutions[zoom]
+            if resolution < min_resolution_seed:
+                _LOGGER.warning(
+                    "zoom %i corresponds to resolution %s is smaller"
+                    " than the 'min_resolution_seed' %s of layer %s, ignored.",
+                    zoom,
+                    resolution,
+                    min_resolution_seed,
+                    layer_name,
+                )
+        self.options.zoom = [z for z in self.options.zoom if resolutions[z] >= min_resolution_seed]
+
+    def _resolve_grid_zooms(
+        self,
+        layer: tilecloud_chain.configuration.Layer,
+        resolutions: list[int | float],
+        grid_name: str,
+        layer_name: str,
+    ) -> list[int]:
+        self._set_default_zoom_for_time(layer, resolutions)
+        self._filter_zoom_outside_grid(resolutions, grid_name, layer_name)
+        self._apply_min_resolution_seed_filter(layer, resolutions, layer_name)
+        if self.options.zoom is None:
+            self.options.zoom = [z for z, _ in enumerate(resolutions)]
+        return list(self.options.zoom)
+
+    @staticmethod
+    def _has_only_nan_bounds(bounds: tuple[float, float, float, float]) -> bool:
+        return all(math.isnan(value) for value in bounds)
+
+    def _get_sparse_grid_tilecoords(
+        self,
+        config: DatedConfig,
+        layer_name: str,
+        grid_name: str,
+        layer: tilecloud_chain.configuration.Layer,
+        grid: tilecloud_chain.configuration.Grid,
+        geoms: dict[str | int, BaseGeometry],
+        zooms: list[int],
+        resolutions: list[int | float],
+    ) -> Iterator[TileCoord]:
+        meta_size = layer.get("meta_size", configuration.LAYER_META_SIZE_DEFAULT)
+        px_buffer = layer.get("px_buffer", configuration.LAYER_PIXEL_BUFFER_DEFAULT)
+        tilegrid = self.get_grid(config, get_grid_name(config, layer_name, grid_name))
+        sparse_bounding_pyramid = SparseMetaTileBoundingPyramid(
+            tilegrid=tilegrid,
+            grid=grid,
+            geoms=geoms,
+            zooms=zooms,
+            resolutions=resolutions,
+            px_buffer=px_buffer,
+        )
+        return sparse_bounding_pyramid.metatilecoords(meta_size)
+
+    def _get_default_grid_tilecoords(
+        self,
+        config: DatedConfig,
+        layer_name: str,
+        grid_name: str,
+        layer: tilecloud_chain.configuration.Layer,
+        geoms: dict[str | int, BaseGeometry],
+        zooms: list[int],
+        resolutions: list[int | float],
+    ) -> Iterable[TileCoord]:
+        tilegrid = self.get_grid(config, get_grid_name(config, layer_name, grid_name))
+        bounding_pyramid = BoundingPyramid(tilegrid=tilegrid)
+        for zoom in zooms:
+            if zoom not in geoms:
+                continue
+            extent = geoms[zoom].bounds
+            if self._has_only_nan_bounds(extent):
+                _LOGGER.warning("bounds empty for zoom %s", zoom)
+                continue
+            minx, miny, maxx, maxy = extent
+            px_buffer = layer.get("px_buffer", configuration.LAYER_PIXEL_BUFFER_DEFAULT)
+            m_buffer = px_buffer * resolutions[zoom]
+            minx -= m_buffer
+            miny -= m_buffer
+            maxx += m_buffer
+            maxy += m_buffer
+            bounding_pyramid.add(
+                tilegrid.tilecoord(
+                    zoom,
+                    max(minx, tilegrid.max_extent[0]),
+                    max(miny, tilegrid.max_extent[1]),
+                ),
+            )
+            bounding_pyramid.add(
+                tilegrid.tilecoord(
+                    zoom,
+                    min(maxx, tilegrid.max_extent[2]),
+                    min(maxy, tilegrid.max_extent[3]),
+                ),
+            )
+        if layer["meta"]:
+            return bounding_pyramid.metatilecoords(layer.get("meta_size", configuration.LAYER_META_SIZE_DEFAULT))
+        return bounding_pyramid
+
     def init_tilecoords(
         self,
         config: DatedConfig,
@@ -1644,105 +1836,31 @@ class TileGeneration:
         for grid_name in grid_names:
             grid = get_grid_config(config, layer_name, grid_name)
             resolutions = grid["resolutions"]
-
-            if self.options.time is not None and self.options.zoom is None:
-                if "min_resolution_seed" in layer:
-                    self.options.zoom = [resolutions.index(layer["min_resolution_seed"])]
-                else:
-                    self.options.zoom = [len(resolutions) - 1]
-
-            if self.options.zoom is not None:
-                zoom_max = len(resolutions) - 1
-                for zoom in self.options.zoom:
-                    if zoom > zoom_max:
-                        _LOGGER.warning(
-                            "zoom %i is greater than the maximum zoom %i of grid %s of layer %s, ignored.",
-                            zoom,
-                            zoom_max,
-                            grid_name,
-                            layer_name,
-                        )
-                self.options.zoom = [z for z in self.options.zoom if z <= zoom_max]
-
-            if "min_resolution_seed" in layer:
-                if self.options.zoom is None:
-                    self.options.zoom = []
-                    for z, resolution in enumerate(resolutions):
-                        if resolution >= layer["min_resolution_seed"]:
-                            self.options.zoom.append(z)
-                else:
-                    for zoom in self.options.zoom:
-                        resolution = resolutions[zoom]
-                        if resolution < layer["min_resolution_seed"]:
-                            _LOGGER.warning(
-                                "zoom %i corresponds to resolution %s is smaller"
-                                " than the 'min_resolution_seed' %s of layer %s, ignored.",
-                                zoom,
-                                resolution,
-                                layer["min_resolution_seed"],
-                                layer_name,
-                            )
-                    self.options.zoom = [
-                        z for z in self.options.zoom if resolutions[z] >= layer["min_resolution_seed"]
-                    ]
-
-            if self.options.zoom is None:
-                self.options.zoom = [z for z, r in enumerate(resolutions)]
-
+            zooms = self._resolve_grid_zooms(layer, resolutions, grid_name, layer_name)
             geoms = self.get_geoms(config, layer_name, grid_name)
 
             if sparse_meta_seed and layer["meta"]:
-                meta_size = layer.get("meta_size", configuration.LAYER_META_SIZE_DEFAULT)
-                px_buffer = layer.get("px_buffer", configuration.LAYER_PIXEL_BUFFER_DEFAULT)
-                tilegrid = self.get_grid(config, get_grid_name(config, layer_name, grid_name))
-                sparse_bounding_pyramid = SparseMetaTileBoundingPyramid(
-                    tilegrid=tilegrid,
-                    grid=grid,
-                    geoms=geoms,
-                    zooms=self.options.zoom,
-                    resolutions=resolutions,
-                    px_buffer=px_buffer,
+                grid_tilecoords[grid_name] = self._get_sparse_grid_tilecoords(
+                    config,
+                    layer_name,
+                    grid_name,
+                    layer,
+                    grid,
+                    geoms,
+                    zooms,
+                    resolutions,
                 )
-                grid_tilecoords[grid_name] = sparse_bounding_pyramid.metatilecoords(meta_size)
                 continue
 
-            # Fill the bounding pyramid
-            tilegrid = self.get_grid(config, get_grid_name(config, layer_name, grid_name))
-            bounding_pyramid = BoundingPyramid(tilegrid=tilegrid)
-            for zoom in self.options.zoom:
-                if zoom in geoms:
-                    extent = geoms[zoom].bounds
-
-                    if len([e for e in extent if not math.isnan(e)]) == 0:
-                        _LOGGER.warning("bounds empty for zoom %s", zoom)
-                    else:
-                        minx, miny, maxx, maxy = extent
-                        px_buffer = layer.get("px_buffer", configuration.LAYER_PIXEL_BUFFER_DEFAULT)
-                        m_buffer = px_buffer * resolutions[zoom]
-                        minx -= m_buffer
-                        miny -= m_buffer
-                        maxx += m_buffer
-                        maxy += m_buffer
-                        bounding_pyramid.add(
-                            tilegrid.tilecoord(
-                                zoom,
-                                max(minx, tilegrid.max_extent[0]),
-                                max(miny, tilegrid.max_extent[1]),
-                            ),
-                        )
-                        bounding_pyramid.add(
-                            tilegrid.tilecoord(
-                                zoom,
-                                min(maxx, tilegrid.max_extent[2]),
-                                min(maxy, tilegrid.max_extent[3]),
-                            ),
-                        )
-            if layer["meta"]:
-                grid_tilecoords[grid_name] = bounding_pyramid.metatilecoords(
-                    layer.get("meta_size", configuration.LAYER_META_SIZE_DEFAULT),
-                )
-            else:
-                grid_tilecoords[grid_name] = bounding_pyramid
+            grid_tilecoords[grid_name] = self._get_default_grid_tilecoords(
+                config,
+                layer_name,
+                grid_name,
+                layer,
+                geoms,
+                zooms,
+                resolutions,
+            )
         self.set_tilecoords(config, grid_tilecoords, layer_name)
 
     @staticmethod

--- a/tilecloud_chain/generate.py
+++ b/tilecloud_chain/generate.py
@@ -223,7 +223,12 @@ class Generate:
 
         if self._options.role in ("local", "master"):
             # Generate a stream of metatiles
-            self._gene.init_tilecoords(config, layer_name, self._options.grid)
+            self._gene.init_tilecoords(
+                config,
+                layer_name,
+                self._options.grid,
+                sparse_meta_seed=self._options.role == "master",
+            )
 
         elif self._options.role == "hash":
             if layer_name not in config.config.get("layers", {}):

--- a/tilecloud_chain/tests/test_generate.py
+++ b/tilecloud_chain/tests/test_generate.py
@@ -5,6 +5,7 @@ from argparse import Namespace
 from itertools import product, repeat
 from pathlib import Path
 from types import SimpleNamespace
+from typing import cast
 from unittest.mock import AsyncMock, Mock
 
 import pytest
@@ -15,6 +16,7 @@ from testfixtures import LogCapture
 from tilecloud.store.redis import RedisTileStore
 
 from tilecloud_chain import SparseMetaTileBoundingPyramid, controller, generate
+from tilecloud_chain import configuration as tcc_configuration
 from tilecloud_chain.settings import settings
 from tilecloud_chain.tests import CompareCase
 
@@ -239,14 +241,14 @@ def test_sparse_metatilecoords_split_by_row() -> None:
 
     bounding_pyramid = SparseMetaTileBoundingPyramid(
         tilegrid=Mock(),
-        grid=grid,
+        grid=cast("tcc_configuration.Grid", grid),
         geoms={0: geom},
         zooms=[0],
         resolutions=[1],
         px_buffer=0,
     )
 
-    metatilecoords = list(bounding_pyramid.metatilecoords(meta_size=1))
+    metatilecoords = list(bounding_pyramid.metatilecoords(1))
 
     assert [(coord.z, coord.x, coord.y, coord.n) for coord in metatilecoords] == [
         (0, 0, 3, 1),
@@ -1410,7 +1412,7 @@ Size per tile: 498 o
             main_func=generate.async_main,
             regex=False,
             expected="""The tile generation of layer 'point (DATE=2012)' is finish
-Nb of generated jobs: 10
+Nb of generated jobs: 6
 
 """,
         )
@@ -1419,7 +1421,7 @@ Nb of generated jobs: 10
             cmd=".build/venv/bin/generate-controller -c tilegeneration/test-redis.yaml --status",
             main_func=controller.async_main,
             regex=False,
-            expected="""Approximate number of tiles to generate: 10
+            expected="""Approximate number of tiles to generate: 6
 Approximate number of generating tiles: 0
 Tiles in error:
 """,
@@ -1430,11 +1432,11 @@ Tiles in error:
             main_func=generate.async_main,
             regex=True,
             expected=r"""The tile generation is finish
-Nb generated metatiles: 10
+Nb generated metatiles: 6
 Nb metatiles dropped: 0
-Nb generated tiles: 640
+Nb generated tiles: 384
 Nb tiles dropped: 0
-Nb tiles stored: 640
+Nb tiles stored: 384
 Nb tiles in error: 0
 Total time: 0:\d\d:\d\d
 Total size: \d+ Kio
@@ -1466,7 +1468,7 @@ Tiles in error:
                 main_func=generate.async_main,
                 regex=False,
                 expected="""The tile generation of layer 'point (DATE=2012)' is finish
-    Nb of generated jobs: 10
+    Nb of generated jobs: 6
 
     """,
             )
@@ -1475,7 +1477,7 @@ Tiles in error:
                 cmd=".build/venv/bin/generate-controller -c tilegeneration/test-redis-project.yaml --status",
                 main_func=controller.async_main,
                 regex=False,
-                expected="""Approximate number of tiles to generate: 10
+                expected="""Approximate number of tiles to generate: 6
     Approximate number of generating tiles: 0
     Tiles in error:
     """,
@@ -1486,11 +1488,11 @@ Tiles in error:
                 main_func=generate.async_main,
                 regex=True,
                 expected=r"""The tile generation is finish
-    Nb generated metatiles: 10
+    Nb generated metatiles: 6
     Nb metatiles dropped: 0
-    Nb generated tiles: 640
+    Nb generated tiles: 384
     Nb tiles dropped: 0
-    Nb tiles stored: 640
+    Nb tiles stored: 384
     Nb tiles in error: 0
     Total time: 0:\d\d:\d\d
     Total size: \d+ Kio

--- a/tilecloud_chain/tests/test_generate.py
+++ b/tilecloud_chain/tests/test_generate.py
@@ -14,7 +14,7 @@ from shapely.geometry import box
 from testfixtures import LogCapture
 from tilecloud.store.redis import RedisTileStore
 
-from tilecloud_chain import DatedConfig, TileGeneration, controller, generate
+from tilecloud_chain import SparseMetaTileBoundingPyramid, controller, generate
 from tilecloud_chain.settings import settings
 from tilecloud_chain.tests import CompareCase
 
@@ -180,7 +180,9 @@ def test_normalize_job_command_arguments() -> None:
 
 
 def test_merge_index_intervals_merges_overlaps_and_adjacency() -> None:
-    assert TileGeneration._merge_index_intervals([(5, 7), (1, 3), (3, 4), (9, 9), (8, 8)]) == [(1, 9)]
+    assert SparseMetaTileBoundingPyramid._merge_index_intervals([(5, 7), (1, 3), (3, 4), (9, 9), (8, 8)]) == [
+        (1, 9),
+    ]
 
 
 @pytest.mark.asyncio
@@ -227,9 +229,7 @@ async def test_generate_queue_disables_sparse_seed_on_local() -> None:
     gene.init_tilecoords.assert_called_once_with(config, "point", None, sparse_meta_seed=False)
 
 
-def test_sparse_metatilecoords_split_by_row_and_cache() -> None:
-    gene = TileGeneration(config_file=AnyioPath("tilegeneration/test-nosns.yaml"), configure_logging=False)
-    config = DatedConfig({"layers": {}, "grids": {}}, 1.0, AnyioPath("config.yaml"))
+def test_sparse_metatilecoords_split_by_row() -> None:
     grid = {
         "bbox": [0, 0, 8, 8],
         "tile_size": 1,
@@ -237,19 +237,16 @@ def test_sparse_metatilecoords_split_by_row_and_cache() -> None:
     }
     geom = box(0.2, 4.2, 1.8, 4.8).union(box(3.2, 4.2, 3.8, 4.8)).union(box(6.2, 2.2, 6.8, 2.8))
 
-    metatilecoords = list(
-        gene._get_sparse_metatilecoords(
-            config,
-            "layer",
-            "grid",
-            grid,
-            geom,
-            zoom=0,
-            resolution=1,
-            meta_size=1,
-            px_buffer=0,
-        ),
+    bounding_pyramid = SparseMetaTileBoundingPyramid(
+        tilegrid=Mock(),
+        grid=grid,
+        geoms={0: geom},
+        zooms=[0],
+        resolutions=[1],
+        px_buffer=0,
     )
+
+    metatilecoords = list(bounding_pyramid.metatilecoords(meta_size=1))
 
     assert [(coord.z, coord.x, coord.y, coord.n) for coord in metatilecoords] == [
         (0, 0, 3, 1),
@@ -257,30 +254,6 @@ def test_sparse_metatilecoords_split_by_row_and_cache() -> None:
         (0, 3, 3, 1),
         (0, 6, 5, 1),
     ]
-
-    intervals = gene._get_sparse_metatile_intervals(
-        config,
-        "layer",
-        "grid",
-        grid,
-        geom,
-        zoom=0,
-        resolution=1,
-        meta_size=1,
-        px_buffer=0,
-    )
-    cached_intervals = gene._get_sparse_metatile_intervals(
-        config,
-        "layer",
-        "grid",
-        grid,
-        box(0, 0, 8, 8),
-        zoom=0,
-        resolution=1,
-        meta_size=1,
-        px_buffer=0,
-    )
-    assert cached_intervals is intervals
 
 
 class TestGenerate(CompareCase):

--- a/tilecloud_chain/tests/test_generate.py
+++ b/tilecloud_chain/tests/test_generate.py
@@ -10,10 +10,11 @@ from unittest.mock import AsyncMock, Mock
 import pytest
 from anyio import Path as AnyioPath
 from PIL import Image
+from shapely.geometry import box
 from testfixtures import LogCapture
 from tilecloud.store.redis import RedisTileStore
 
-from tilecloud_chain import controller, generate
+from tilecloud_chain import DatedConfig, TileGeneration, controller, generate
 from tilecloud_chain.settings import settings
 from tilecloud_chain.tests import CompareCase
 
@@ -176,6 +177,97 @@ def test_normalize_job_command_arguments() -> None:
     assert generate._normalize_job_command_arguments(
         ["/tmp/.build/venv/bin/generate-tiles", "--role", "master", "--job-title=my title"],
     ) == ["generate-tiles", "--role", "master"]
+
+
+def test_merge_index_intervals_merges_overlaps_and_adjacency() -> None:
+    assert TileGeneration._merge_index_intervals([(5, 7), (1, 3), (3, 4), (9, 9), (8, 8)]) == [(1, 9)]
+
+
+@pytest.mark.asyncio
+async def test_generate_queue_enables_sparse_seed_on_master() -> None:
+    options = Namespace(
+        get_hash=None,
+        tiles=None,
+        role="master",
+        get_bbox=None,
+        tile=None,
+        grid=None,
+    )
+    gene = Mock()
+    gene.config_file = AnyioPath("config.yaml")
+    config = SimpleNamespace(config={"layers": {"point": {}}})
+    gene.get_config = AsyncMock(return_value=config)
+    gene.init_tilecoords = Mock()
+
+    generate_ = generate.Generate(options, gene, out=None)
+    await generate_._generate_queue("point")  # noqa: SLF001
+
+    gene.init_tilecoords.assert_called_once_with(config, "point", None, sparse_meta_seed=True)
+
+
+@pytest.mark.asyncio
+async def test_generate_queue_disables_sparse_seed_on_local() -> None:
+    options = Namespace(
+        get_hash=None,
+        tiles=None,
+        role="local",
+        get_bbox=None,
+        tile=None,
+        grid=None,
+    )
+    gene = Mock()
+    gene.config_file = AnyioPath("config.yaml")
+    config = SimpleNamespace(config={"layers": {"point": {}}})
+    gene.get_config = AsyncMock(return_value=config)
+    gene.init_tilecoords = Mock()
+
+    generate_ = generate.Generate(options, gene, out=None)
+    await generate_._generate_queue("point")  # noqa: SLF001
+
+    gene.init_tilecoords.assert_called_once_with(config, "point", None, sparse_meta_seed=False)
+
+
+def test_sparse_metatilecoords_split_by_row_and_cache() -> None:
+    gene = TileGeneration(config_file=AnyioPath("tilegeneration/test-nosns.yaml"), configure_logging=False)
+    config = DatedConfig({"layers": {}, "grids": {}}, 1.0, AnyioPath("config.yaml"))
+    grid = {
+        "bbox": [0, 0, 8, 8],
+        "tile_size": 1,
+        "resolutions": [1],
+    }
+    geom = box(0.2, 4.2, 1.8, 4.8).union(box(3.2, 4.2, 3.8, 4.8)).union(box(6.2, 2.2, 6.8, 2.8))
+
+    metatilecoords = gene._get_sparse_metatilecoords(
+        config,
+        "layer",
+        "grid",
+        grid,
+        geom,
+        zoom=0,
+        resolution=1,
+        meta_size=1,
+        px_buffer=0,
+    )
+
+    assert [(coord.z, coord.x, coord.y, coord.n) for coord in metatilecoords] == [
+        (0, 0, 3, 1),
+        (0, 1, 3, 1),
+        (0, 3, 3, 1),
+        (0, 6, 5, 1),
+    ]
+
+    cached = gene._get_sparse_metatilecoords(
+        config,
+        "layer",
+        "grid",
+        grid,
+        box(0, 0, 8, 8),
+        zoom=0,
+        resolution=1,
+        meta_size=1,
+        px_buffer=0,
+    )
+    assert cached is metatilecoords
 
 
 class TestGenerate(CompareCase):

--- a/tilecloud_chain/tests/test_generate.py
+++ b/tilecloud_chain/tests/test_generate.py
@@ -237,7 +237,28 @@ def test_sparse_metatilecoords_split_by_row_and_cache() -> None:
     }
     geom = box(0.2, 4.2, 1.8, 4.8).union(box(3.2, 4.2, 3.8, 4.8)).union(box(6.2, 2.2, 6.8, 2.8))
 
-    metatilecoords = gene._get_sparse_metatilecoords(
+    metatilecoords = list(
+        gene._get_sparse_metatilecoords(
+            config,
+            "layer",
+            "grid",
+            grid,
+            geom,
+            zoom=0,
+            resolution=1,
+            meta_size=1,
+            px_buffer=0,
+        ),
+    )
+
+    assert [(coord.z, coord.x, coord.y, coord.n) for coord in metatilecoords] == [
+        (0, 0, 3, 1),
+        (0, 1, 3, 1),
+        (0, 3, 3, 1),
+        (0, 6, 5, 1),
+    ]
+
+    intervals = gene._get_sparse_metatile_intervals(
         config,
         "layer",
         "grid",
@@ -248,15 +269,7 @@ def test_sparse_metatilecoords_split_by_row_and_cache() -> None:
         meta_size=1,
         px_buffer=0,
     )
-
-    assert [(coord.z, coord.x, coord.y, coord.n) for coord in metatilecoords] == [
-        (0, 0, 3, 1),
-        (0, 1, 3, 1),
-        (0, 3, 3, 1),
-        (0, 6, 5, 1),
-    ]
-
-    cached = gene._get_sparse_metatilecoords(
+    cached_intervals = gene._get_sparse_metatile_intervals(
         config,
         "layer",
         "grid",
@@ -267,7 +280,7 @@ def test_sparse_metatilecoords_split_by_row_and_cache() -> None:
         meta_size=1,
         px_buffer=0,
     )
-    assert cached is metatilecoords
+    assert cached_intervals is intervals
 
 
 class TestGenerate(CompareCase):


### PR DESCRIPTION
## Summary
- Speed up `generate-tiles --role=master` queue seeding for sparse geometries by generating metatile candidates from per-row scanline intervals instead of scanning full bounding pyramids.
- Keep local/slave behavior unchanged and preserve downstream geometry filtering as a safety net.
- Add coverage for interval merging, master/local sparse-seed selection, sparse scanline coordinate generation, and cache reuse.