### PR TITLE
Add GDAL datasource support for layer geoms

### DIFF
--- a/.github/spell-ignore-words.txt
+++ b/.github/spell-ignore-words.txt
@@ -13,3 +13,4 @@ OpenLayers
 pyproj
 geoms
 bbox
+mask.geojson

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 The project must use async-friendly APIs for I/O to don't block the event loop.
 
-- `pathlib` must not be used, use `anyio.Path` instead.
+- `pathlib` must not be used in application code, use `anyio.Path` instead.
 - Converting a non-async function to `async` is allowed, and requires updating all call sites to `await` it.
 - `aiofiles` must not be used, use `anyio.Path` instead.
 - All disk or network operation must be done with async API; avoid blocking calls on the event loop.
@@ -83,6 +83,8 @@ The changes in the codebase that affect the user should be documented in the `CH
 The new functionalities should be reasonably tested in the `tilecloud_chain/tests/` folder.
 
 Test files in `tilecloud_chain/tests/` may not follow the rules concerning `async` requirements, as there are no performance requirements.
+
+Test files in `tilecloud_chain/tests/` may use `pathlib` when it is simpler for synchronous fixtures/assertions.
 
 To run the tests, use the `make tests` command.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Keep WMS XML error newlines in tile error logs and remove extra spaces in the admin job status header `(date, status)` display.
 - Auto-create a PostgreSQL job when `generate-tiles --role=master` runs without `--job-id`, using `User call` as default title and allowing override with `--job-title=<title>`.
 - Speed up `generate-tiles --role=master` queue seeding for metatile layers by using per-row metatile scanline intervals instead of full bounding-pyramid scans, reducing candidate metatiles especially on sparse datasets.
+- Add support for `layers.<name>.geoms[].datasource` to load geometry masks from a GDAL datasource (for example a Shapefile), with relative paths resolved from the layer configuration file.
 
 Environment variable migration (legacy -> new)
 

--- a/tilecloud_chain/CONFIG.md
+++ b/tilecloud_chain/CONFIG.md
@@ -159,8 +159,10 @@
 - <a id="definitions/layer_post_process"></a>**`layer_post_process`** *(string)*: Do an image post process after the empty hash check.
 - <a id="definitions/layer_geoms"></a>**`layer_geoms`** *(array)*: The geometries used to determine where we should create the tiles, see https://github.com/camptocamp/tilecloud-chain/blob/master/tilecloud_chain/USAGE.rst#configure-geomsql.
   - <a id="definitions/layer_geoms/items"></a>**Items** *(object)*: Cannot contain additional properties.
-    - <a id="definitions/layer_geoms/items/properties/connection"></a>**`connection`** *(string, required)*: The PostgreSQL connection string.
-    - <a id="definitions/layer_geoms/items/properties/sql"></a>**`sql`** *(string, required)*: The SQL query that get the geometry in geom e.g. `the_geom AS geom FROM my_table`.
+    - **Any of**
+    - <a id="definitions/layer_geoms/items/properties/connection"></a>**`connection`** *(string)*: The PostgreSQL connection string.
+    - <a id="definitions/layer_geoms/items/properties/datasource"></a>**`datasource`** *(string)*: The GDAL data source relative path (for example geoms_mask.geojson).
+    - <a id="definitions/layer_geoms/items/properties/sql"></a>**`sql`** *(string)*: For PostgreSQL source: SQL query that gets the geometry in `geom` (e.g. `the_geom AS geom FROM my_table`). For file data source: optional OGR SQL query.
     - <a id="definitions/layer_geoms/items/properties/min_resolution"></a>**`min_resolution`** *(number)*: The min resolution where the query is valid.
     - <a id="definitions/layer_geoms/items/properties/max_resolution"></a>**`max_resolution`** *(number)*: The max resolution where the query is valid.
 - <a id="definitions/layer_empty_tile_detection"></a>**`layer_empty_tile_detection`** *(object)*: The rules used to detect the empty tiles, use `generate-tiles --get-hash` to get what we can use, see https://github.com/camptocamp/tilecloud-chain/blob/master/tilecloud_chain/USAGE.rst#configure-hash. Cannot contain additional properties.

--- a/tilecloud_chain/USAGE.rst
+++ b/tilecloud_chain/USAGE.rst
@@ -160,7 +160,9 @@ zoom, x and y as 0.
 Configure geom/sql
 ^^^^^^^^^^^^^^^^^^
 
-We can generate the tiles only on some geometries stored in PostGis.
+We can generate the tiles only on some geometries.
+
+PostGIS source configuration:
 
 The configuration is in the layer like this:
 
@@ -171,6 +173,19 @@ The configuration is in the layer like this:
         sql: <column> AS geom FROM <table>
         min_resolution: <resolution> # included, optional, last win
         max_resolution: <resolution> # included, optional, last win
+
+GDAL data source configuration (for example a shapefile):
+
+.. code:: yaml
+
+    geoms:
+    -   datasource: geoms/mask
+        sql: SELECT * FROM mask_layer # optional OGR SQL
+        min_resolution: <resolution> # included, optional, last win
+        max_resolution: <resolution> # included, optional, last win
+
+The ``datasource`` should be a relative file path from the configuration file
+directory and should stay inside that directory.
 
 Example:
 

--- a/tilecloud_chain/__init__.py
+++ b/tilecloud_chain/__init__.py
@@ -40,7 +40,7 @@ from c2cwsgiutils import sentry
 from PIL import Image
 from prometheus_client import Counter, Summary
 from ruamel.yaml import YAML
-from shapely.geometry import box
+from shapely.geometry import GeometryCollection, box, shape
 from shapely.geometry.base import BaseGeometry
 from shapely.geometry.polygon import Polygon
 from shapely.ops import unary_union
@@ -57,7 +57,6 @@ from tilecloud.store.redis import RedisTileStore
 from tilecloud.store.s3 import S3TileStore
 from tilecloud.store.sqs import SQSTileStore, _maybe_stop
 
-import tilecloud_chain.configuration
 from tilecloud_chain import configuration
 from tilecloud_chain.filter.error import MaximumConsecutiveErrors, TooManyError
 from tilecloud_chain.multitilestore import MultiTileStore
@@ -216,7 +215,7 @@ def add_common_options(
 
 
 def get_tile_matrix_identifier(
-    grid: tilecloud_chain.configuration.Grid,
+    grid: configuration.Grid,
     resolution: float | None = None,
     zoom: int | None = None,
 ) -> str:
@@ -376,7 +375,7 @@ class DatedConfig:
 
     def __init__(
         self,
-        config: tilecloud_chain.configuration.Configuration,
+        config: configuration.Configuration,
         mtime: float,
         file: Path,
     ) -> None:
@@ -415,7 +414,7 @@ class SparseMetaTileBoundingPyramid(BoundingPyramid):
     def __init__(
         self,
         tilegrid: TileGrid,
-        grid: tilecloud_chain.configuration.Grid,
+        grid: configuration.Grid,
         geoms: dict[str | int, BaseGeometry],
         zooms: Iterable[int],
         resolutions: list[int | float],
@@ -687,7 +686,7 @@ def get_grid_config(
     config: DatedConfig,
     layer_name: str,
     grid_name: str | None,
-) -> tilecloud_chain.configuration.Grid:
+) -> configuration.Grid:
     """Get the grid configuration."""
     return config.config["grids"][get_grid_name(config, layer_name, grid_name)]
 
@@ -840,7 +839,7 @@ class TileGeneration:
         self,
         config_file: Path | None = None,
         options: Namespace | None = None,
-        base_config: tilecloud_chain.configuration.Configuration | None = None,
+        base_config: configuration.Configuration | None = None,
         configure_logging: bool = True,
         multi_task: bool = True,
         maxconsecutive_errors: bool = True,
@@ -858,7 +857,7 @@ class TileGeneration:
         self.maxconsecutive_errors = maxconsecutive_errors
         self.out = out
         self.grid_cache: dict[Path, dict[str, DatedTileGrid]] = {}
-        self.layer_legends: dict[str, list[tilecloud_chain.configuration.LayerLegendItem]] = {}
+        self.layer_legends: dict[str, list[configuration.LayerLegendItem]] = {}
         self.config_file = config_file
         self.base_config = base_config
         self.multi_task = multi_task
@@ -1017,7 +1016,7 @@ class TileGeneration:
         return (
             await self.get_config(config_file)
             if config_file
-            else DatedConfig(cast("tilecloud_chain.configuration.Configuration", {}), 0, Path())
+            else DatedConfig(cast("configuration.Configuration", {}), 0, Path())
         )
 
     async def get_tile_config(self, tile: Tile) -> DatedConfig:
@@ -1028,13 +1027,13 @@ class TileGeneration:
         self,
         config_file: Path,
         ignore_error: bool = True,
-        base_config: tilecloud_chain.configuration.Configuration | None = None,
+        base_config: configuration.Configuration | None = None,
     ) -> DatedConfig:
         """Get the validated configuration for the file name, with cache management."""
         if not await config_file.exists():
             _LOGGER.error("Missing config file %s", config_file)
             if ignore_error:
-                return DatedConfig(cast("tilecloud_chain.configuration.Configuration", {}), 0, Path())
+                return DatedConfig(cast("configuration.Configuration", {}), 0, Path())
             sys.exit(1)
 
         config: DatedConfig | None = self.configs.get(config_file)
@@ -1046,7 +1045,7 @@ class TileGeneration:
         config, success = await self._get_config(config_file, ignore_error, base_config)
         if not success or config is None:
             if ignore_error:
-                config = DatedConfig(cast("tilecloud_chain.configuration.Configuration", {}), 0, Path())
+                config = DatedConfig(cast("configuration.Configuration", {}), 0, Path())
             else:
                 sys.exit(1)
         self.configs[config_file] = config
@@ -1104,7 +1103,7 @@ class TileGeneration:
         self,
         config_file: Path,
         ignore_error: bool,
-        base_config: tilecloud_chain.configuration.Configuration | None = None,
+        base_config: configuration.Configuration | None = None,
     ) -> tuple[DatedConfig, bool]:
         """Get the validated configuration for the file name."""
 
@@ -1117,7 +1116,7 @@ class TileGeneration:
 
         config_stat = await config_file.stat()
         dated_config = DatedConfig(
-            cast("tilecloud_chain.configuration.Configuration", config),
+            cast("configuration.Configuration", config),
             config_stat.st_mtime,
             config_file,
         )
@@ -1227,7 +1226,7 @@ class TileGeneration:
             result *= fact**nb
         return result
 
-    def get_all_dimensions(self, layer: tilecloud_chain.configuration.Layer) -> list[dict[str, str]]:
+    def get_all_dimensions(self, layer: configuration.Layer) -> list[dict[str, str]]:
         """Get all the dimensions."""
         assert layer is not None
 
@@ -1249,7 +1248,7 @@ class TileGeneration:
     async def get_store(
         self,
         config: DatedConfig,
-        cache: tilecloud_chain.configuration.Cache,
+        cache: configuration.Cache,
         layer_name: str,
         grid_name: str | None,
         read_only: bool = False,
@@ -1272,7 +1271,7 @@ class TileGeneration:
         )
         # store
         if cache["type"] == "s3":
-            cache_s3 = cast("tilecloud_chain.configuration.CacheS3", cache)
+            cache_s3 = cast("configuration.CacheS3", cache)
             # on s3
             cache_tilestore: AsyncTileStore = TileStoreWrapper(
                 S3TileStore(
@@ -1283,7 +1282,7 @@ class TileGeneration:
                 ),
             )
         elif cache["type"] == "azure":
-            cache_azure = cast("tilecloud_chain.configuration.CacheAzureTyped", cache)
+            cache_azure = cast("configuration.CacheAzureTyped", cache)
             # on Azure
             cache_tilestore = AzureStorageBlobTileStore(
                 tilelayout=layout,
@@ -1622,15 +1621,13 @@ class TileGeneration:
                 geoms[z] = geom
 
         if self.options.near is None and self.options.geom:
-            for g in layer.get("geoms", []):
-                with _GEOMS_GET_SUMMARY.labels(layer_name, host or self.options.host).time():
-                    connection = psycopg2.connect(g["connection"])
-                    cursor = connection.cursor()
-                    sql = f"SELECT ST_AsBinary(geom) FROM (SELECT {g['sql']}) AS g"  # nosec # noqa: S608
-                    _LOGGER.info("Execute SQL: %s.", sql)
-                    cursor.execute(sql)
-                    geom_list = [loads_wkb(bytes(r[0])) for r in cursor.fetchall()]
-                    geom = unary_union(geom_list)
+            for geom_source in layer.get("geoms", cast("configuration.LayerGeometries", [])):
+                metrics_host = host or self.options.host
+                with _GEOMS_GET_SUMMARY.labels(layer_name, metrics_host).time():
+                    if "datasource" in geom_source:
+                        geom = self._load_geom_from_datasource(config.file, geom_source)
+                    else:
+                        geom = self._load_geom_from_postgis(geom_source)
 
                     # Reproject the geometry if needed
                     if (
@@ -1657,12 +1654,10 @@ class TileGeneration:
                             ),
                         )
                     for z, r in enumerate(grid["resolutions"]):
-                        if ("min_resolution" not in g or g["min_resolution"] <= r) and (
-                            "max_resolution" not in g or g["max_resolution"] >= r
+                        if ("min_resolution" not in geom_source or geom_source["min_resolution"] <= r) and (
+                            "max_resolution" not in geom_source or geom_source["max_resolution"] >= r
                         ):
                             geoms[z] = geom
-                    cursor.close()
-                    connection.close()
 
         self.geoms_cache.setdefault(config.file, {}).setdefault(layer_name, {})[grid_name] = DatedGeoms(
             geoms,
@@ -1670,9 +1665,92 @@ class TileGeneration:
         )
         return geoms
 
+    @staticmethod
+    def _resolve_gdal_datasource(config_file: Path, datasource: str) -> str:
+        """Resolve a GDAL datasource path relative to the config file when applicable."""
+        if re.match(r"^[A-Za-z][A-Za-z0-9+.-]*:", datasource):
+            message = "Only relative file paths are allowed in geoms.datasource."
+            raise ValueError(message)
+        datasource_path = Path(datasource)
+        if datasource_path.is_absolute():
+            message = "Only relative file paths are allowed in geoms.datasource."
+            raise ValueError(message)
+        if ".." in datasource_path.parts:
+            message = "The geoms.datasource path should stay inside the config directory."
+            raise ValueError(message)
+
+        config_directory = os.path.realpath(str(config_file.parent))
+        resolved_datasource = os.path.realpath(
+            os.path.normpath(str(config_file.parent / datasource_path)),
+        )
+        if os.path.commonpath([config_directory, resolved_datasource]) != config_directory:
+            message = "The geoms.datasource path should stay inside the config directory."
+            raise ValueError(message)
+        return resolved_datasource
+
+    @staticmethod
+    def _load_geom_from_postgis(geom_source: configuration.LayerGeometry) -> BaseGeometry:
+        """Load one geometry from a PostGIS source."""
+        connection = psycopg2.connect(geom_source["connection"])
+        try:
+            cursor = connection.cursor()
+            try:
+                sql = f"SELECT ST_AsBinary(geom) FROM (SELECT {geom_source['sql']}) AS g"  # nosec # noqa: S608
+                _LOGGER.info("Execute SQL: %s.", sql)
+                cursor.execute(sql)
+                geom_list = [loads_wkb(bytes(result[0])) for result in cursor.fetchall()]
+            finally:
+                cursor.close()
+        finally:
+            connection.close()
+        return unary_union(geom_list)
+
+    @staticmethod
+    def _load_geom_from_datasource(
+        config_file: Path, geom_source: configuration.LayerGeometry
+    ) -> BaseGeometry:
+        """Load one geometry from a GDAL datasource."""
+        datasource = TileGeneration._resolve_gdal_datasource(config_file, geom_source["datasource"])
+        geometries = TileGeneration._read_ogr_geometries(datasource, geom_source.get("sql"))
+
+        if not geometries:
+            return GeometryCollection()
+
+        return unary_union(geometries)
+
+    @staticmethod
+    def _read_ogr_geometries(datasource: str, sql: str | None) -> list[BaseGeometry]:
+        """Read geometries from a GDAL datasource using OGR."""
+        try:
+            from osgeo import ogr
+        except ModuleNotFoundError as exception:
+            message = "Unable to load GDAL Python bindings (osgeo.ogr)."
+            raise RuntimeError(message) from exception
+
+        data_source = ogr.Open(datasource)
+        if data_source is None:
+            message = f"Unable to open GDAL datasource '{datasource}'."
+            raise RuntimeError(message)
+
+        layer = data_source.ExecuteSQL(sql) if sql is not None else data_source.GetLayer()
+        if layer is None:
+            message = f"Unable to read GDAL datasource '{datasource}'."
+            raise RuntimeError(message)
+
+        try:
+            geometries = []
+            for feature in layer:
+                geometry = feature.GetGeometryRef()
+                if geometry is not None:
+                    geometries.append(shape(json.loads(geometry.ExportToJson())))
+            return geometries
+        finally:
+            if sql is not None:
+                data_source.ReleaseResultSet(layer)
+
     def _set_default_zoom_for_time(
         self,
-        layer: tilecloud_chain.configuration.Layer,
+        layer: configuration.Layer,
         resolutions: list[int | float],
     ) -> None:
         if self.options.time is None or self.options.zoom is not None:
@@ -1704,7 +1782,7 @@ class TileGeneration:
 
     def _apply_min_resolution_seed_filter(
         self,
-        layer: tilecloud_chain.configuration.Layer,
+        layer: configuration.Layer,
         resolutions: list[int | float],
         layer_name: str,
     ) -> None:
@@ -1731,7 +1809,7 @@ class TileGeneration:
 
     def _resolve_grid_zooms(
         self,
-        layer: tilecloud_chain.configuration.Layer,
+        layer: configuration.Layer,
         resolutions: list[int | float],
         grid_name: str,
         layer_name: str,
@@ -1752,8 +1830,8 @@ class TileGeneration:
         config: DatedConfig,
         layer_name: str,
         grid_name: str,
-        layer: tilecloud_chain.configuration.Layer,
-        grid: tilecloud_chain.configuration.Grid,
+        layer: configuration.Layer,
+        grid: configuration.Grid,
         geoms: dict[str | int, BaseGeometry],
         zooms: list[int],
         resolutions: list[int | float],
@@ -1776,7 +1854,7 @@ class TileGeneration:
         config: DatedConfig,
         layer_name: str,
         grid_name: str,
-        layer: tilecloud_chain.configuration.Layer,
+        layer: configuration.Layer,
         geoms: dict[str | int, BaseGeometry],
         zooms: list[int],
         resolutions: list[int | float],
@@ -2391,7 +2469,7 @@ def parse_tilecoord(string_representation: str) -> TileCoord:
 class Process:
     """Process a tile throw an external command."""
 
-    def __init__(self, config: tilecloud_chain.configuration.ProcessCommand, options: Namespace) -> None:
+    def __init__(self, config: configuration.ProcessCommand, options: Namespace) -> None:
         self.config = config
         self.options: list[Literal["verbose", "debug", "quiet", "default"]] = []
         if options.verbose:

--- a/tilecloud_chain/configuration.py
+++ b/tilecloud_chain/configuration.py
@@ -1309,12 +1309,61 @@ The layer extension
 
 
 
-LayerGeometries = list["_LayerGeometriesItem"]
+LayerGeometries = list["LayerGeometry"]
 r"""
 Layer geometries.
 
 The geometries used to determine where we should create the tiles, see https://github.com/camptocamp/tilecloud-chain/blob/master/tilecloud_chain/USAGE.rst#configure-geomsql
 """
+
+
+
+class LayerGeometry(TypedDict, total=False):
+    r"""
+    Layer geometry.
+
+    anyOf:
+      - required:
+        - connection
+        - sql
+      - required:
+        - datasource
+    """
+
+    connection: str
+    r"""
+    Connection.
+
+    The PostgreSQL connection string
+    """
+
+    datasource: str
+    r"""
+    Datasource.
+
+    The GDAL data source relative path (for example geoms_mask.geojson)
+    """
+
+    sql: str
+    r"""
+    SQL.
+
+    For PostgreSQL source: SQL query that gets the geometry in `geom` (e.g. `the_geom AS geom FROM my_table`). For file data source: optional OGR SQL query.
+    """
+
+    min_resolution: int | float
+    r"""
+    Min resolution.
+
+    The min resolution where the query is valid
+    """
+
+    max_resolution: int | float
+    r"""
+    Max resolution.
+
+    The max resolution where the query is valid
+    """
 
 
 
@@ -3065,41 +3114,6 @@ r""" Default value of the field path 'Layer WMS meta_buffer' """
 
 _LAYER_WMS_META_SIZE_DEFAULT = 5
 r""" Default value of the field path 'Layer WMS meta_size' """
-
-
-
-class _LayerGeometriesItem(TypedDict, total=False):
-    connection: Required[str]
-    r"""
-    Connection.
-
-    The PostgreSQL connection string
-
-    Required property
-    """
-
-    sql: Required[str]
-    r"""
-    SQL.
-
-    The SQL query that get the geometry in geom e.g. `the_geom AS geom FROM my_table`
-
-    Required property
-    """
-
-    min_resolution: int | float
-    r"""
-    Min resolution.
-
-    The min resolution where the query is valid
-    """
-
-    max_resolution: int | float
-    r"""
-    Max resolution.
-
-    The max resolution where the query is valid
-    """
 
 
 

--- a/tilecloud_chain/schema.json
+++ b/tilecloud_chain/schema.json
@@ -495,6 +495,7 @@
       "type": "array",
       "items": {
         "type": "object",
+        "title": "Layer geometry",
         "additionalProperties": false,
         "properties": {
           "connection": {
@@ -502,9 +503,14 @@
             "description": "The PostgreSQL connection string",
             "type": "string"
           },
+          "datasource": {
+            "title": "Datasource",
+            "description": "The GDAL data source relative path (for example geoms_mask.geojson)",
+            "type": "string"
+          },
           "sql": {
             "title": "SQL",
-            "description": "The SQL query that get the geometry in geom e.g. `the_geom AS geom FROM my_table`",
+            "description": "For PostgreSQL source: SQL query that gets the geometry in `geom` (e.g. `the_geom AS geom FROM my_table`). For file data source: optional OGR SQL query.",
             "type": "string"
           },
           "min_resolution": {
@@ -518,7 +524,14 @@
             "type": "number"
           }
         },
-        "required": ["connection", "sql"]
+        "anyOf": [
+          {
+            "required": ["connection", "sql"]
+          },
+          {
+            "required": ["datasource"]
+          }
+        ]
       }
     },
     "layer_empty_tile_detection": {

--- a/tilecloud_chain/tests/test_generate.py
+++ b/tilecloud_chain/tests/test_generate.py
@@ -1,11 +1,12 @@
 import json
 import os
 import shutil
+import sys
 from argparse import Namespace
 from itertools import product, repeat
 from pathlib import Path
 from types import SimpleNamespace
-from typing import cast
+from typing import Any, cast
 from unittest.mock import AsyncMock, Mock
 
 import pytest
@@ -15,7 +16,7 @@ from shapely.geometry import box
 from testfixtures import LogCapture
 from tilecloud.store.redis import RedisTileStore
 
-from tilecloud_chain import SparseMetaTileBoundingPyramid, controller, generate
+from tilecloud_chain import DatedConfig, SparseMetaTileBoundingPyramid, TileGeneration, controller, generate
 from tilecloud_chain import configuration as tcc_configuration
 from tilecloud_chain.settings import settings
 from tilecloud_chain.tests import CompareCase
@@ -256,6 +257,211 @@ def test_sparse_metatilecoords_split_by_row() -> None:
         (0, 3, 3, 1),
         (0, 6, 5, 1),
     ]
+
+
+def test_resolve_gdal_datasource_relative() -> None:
+    datasource = TileGeneration._resolve_gdal_datasource(
+        AnyioPath("/tmp/tilegeneration/config.yaml"),
+        "geoms/mask.geojson",
+    )
+    assert datasource == "/tmp/tilegeneration/geoms/mask.geojson"
+
+
+def test_resolve_gdal_datasource_uri() -> None:
+    with pytest.raises(ValueError, match="Only relative file paths"):
+        TileGeneration._resolve_gdal_datasource(
+            AnyioPath("/tmp/tilegeneration/config.yaml"),
+            "PG:host=db dbname=tests",
+        )
+
+
+def test_resolve_gdal_datasource_parent_not_allowed() -> None:
+    with pytest.raises(ValueError, match="inside the config directory"):
+        TileGeneration._resolve_gdal_datasource(
+            AnyioPath("/tmp/tilegeneration/config.yaml"),
+            "../mask.geojson",
+        )
+
+
+def test_resolve_gdal_datasource_absolute_not_allowed() -> None:
+    with pytest.raises(ValueError, match="Only relative file paths"):
+        TileGeneration._resolve_gdal_datasource(
+            AnyioPath("/tmp/tilegeneration/config.yaml"),
+            "/tmp/mask.geojson",
+        )
+
+
+def test_load_geom_from_datasource_with_sql(monkeypatch: pytest.MonkeyPatch) -> None:
+    read_args: tuple[str, str | None] | None = None
+
+    def _read_ogr_geometries(datasource: str, sql: str | None) -> list[Any]:
+        nonlocal read_args
+        read_args = (datasource, sql)
+        return []
+
+    monkeypatch.setattr(TileGeneration, "_read_ogr_geometries", _read_ogr_geometries)
+
+    geom = TileGeneration._load_geom_from_datasource(
+        AnyioPath("/tmp/tilegeneration/config.yaml"),
+        {"datasource": "geoms/mask.geojson", "sql": "SELECT * FROM mask"},
+    )
+
+    assert read_args == ("/tmp/tilegeneration/geoms/mask.geojson", "SELECT * FROM mask")
+    assert geom.is_empty
+
+
+def test_get_geoms_from_datasource(monkeypatch: pytest.MonkeyPatch) -> None:
+    read_args: tuple[str, str | None] | None = None
+
+    def _read_ogr_geometries(datasource: str, sql: str | None) -> list[Any]:
+        nonlocal read_args
+        read_args = (datasource, sql)
+        return [box(550000, 170000, 560000, 180000)]
+
+    monkeypatch.setattr(TileGeneration, "_read_ogr_geometries", _read_ogr_geometries)
+
+    gene = TileGeneration(
+        options=Namespace(
+            verbose=False,
+            debug=False,
+            quiet=False,
+            bbox=None,
+            zoom=None,
+            test=None,
+            near=None,
+            time=None,
+            geom=True,
+            ignore_error=False,
+            host="localhost",
+        ),
+        configure_logging=False,
+    )
+    config = DatedConfig(
+        {
+            "grids": {
+                "swissgrid_5": {
+                    "resolutions": [1000, 500, 250],
+                    "bbox": [420000, 30000, 900000, 350000],
+                    "srs": "EPSG:21781",
+                },
+            },
+            "layers": {
+                "point_datasource": {
+                    "type": "wms",
+                    "url": "http://mapserver:8080/",
+                    "layers": "point",
+                    "wmts_style": "default",
+                    "mime_type": "image/png",
+                    "extension": "png",
+                    "grid": "swissgrid_5",
+                    "geoms": [{"datasource": "geoms/mask.geojson"}],
+                },
+            },
+        },
+        0,
+        AnyioPath("/tmp/tilegeneration/test-geoms-datasource.yaml"),
+    )
+
+    geoms = gene.get_geoms(config, "point_datasource", "swissgrid_5")
+
+    assert read_args == ("/tmp/tilegeneration/geoms/mask.geojson", None)
+    assert sorted(geoms.keys()) == [0, 1, 2]
+    assert geoms[0].bounds == (550000.0, 170000.0, 560000.0, 180000.0)
+
+
+def test_read_ogr_geometries_uses_sql_and_releases_result_set(monkeypatch: pytest.MonkeyPatch) -> None:
+    execute_sql_calls: list[str] = []
+    release_calls = 0
+
+    class _Geometry:
+        def ExportToJson(self) -> str:  # noqa: N802
+            return json.dumps({"type": "Point", "coordinates": [1, 2]})
+
+    class _Feature:
+        @staticmethod
+        def GetGeometryRef() -> _Geometry:  # noqa: N802
+            return _Geometry()
+
+    class _Layer:
+        def __iter__(self):
+            return iter([_Feature()])
+
+    class _DataSource:
+        def GetLayer(self) -> _Layer:  # noqa: N802
+            return _Layer()
+
+        def ExecuteSQL(self, sql: str) -> _Layer:  # noqa: N802
+            execute_sql_calls.append(sql)
+            return _Layer()
+
+        def ReleaseResultSet(self, _layer: _Layer) -> None:  # noqa: N802
+            nonlocal release_calls
+            release_calls += 1
+
+    class _Ogr:
+        @staticmethod
+        def Open(_datasource: str) -> _DataSource:  # noqa: N802
+            return _DataSource()
+
+    monkeypatch.setitem(sys.modules, "osgeo", SimpleNamespace(ogr=_Ogr()))
+
+    geometries = TileGeneration._read_ogr_geometries("/tmp/mask.geojson", "SELECT * FROM mask")
+
+    assert len(geometries) == 1
+    assert execute_sql_calls == ["SELECT * FROM mask"]
+    assert release_calls == 1
+
+
+def test_read_ogr_geometries_without_sql_uses_default_layer(monkeypatch: pytest.MonkeyPatch) -> None:
+    get_layer_calls = 0
+
+    class _Geometry:
+        def ExportToJson(self) -> str:  # noqa: N802
+            return json.dumps({"type": "Point", "coordinates": [1, 2]})
+
+    class _Feature:
+        @staticmethod
+        def GetGeometryRef() -> _Geometry:  # noqa: N802
+            return _Geometry()
+
+    class _Layer:
+        def __iter__(self):
+            return iter([_Feature()])
+
+    class _DataSource:
+        def GetLayer(self) -> _Layer:  # noqa: N802
+            nonlocal get_layer_calls
+            get_layer_calls += 1
+            return _Layer()
+
+        def ExecuteSQL(self, _sql: str) -> _Layer:  # noqa: N802
+            raise AssertionError("ExecuteSQL should not be called without sql")
+
+        def ReleaseResultSet(self, _layer: _Layer) -> None:  # noqa: N802
+            raise AssertionError("ReleaseResultSet should not be called without sql")
+
+    class _Ogr:
+        @staticmethod
+        def Open(_datasource: str) -> _DataSource:  # noqa: N802
+            return _DataSource()
+
+    monkeypatch.setitem(sys.modules, "osgeo", SimpleNamespace(ogr=_Ogr()))
+
+    geometries = TileGeneration._read_ogr_geometries("/tmp/mask.geojson", None)
+
+    assert len(geometries) == 1
+    assert get_layer_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_datasource_geom_config_is_valid() -> None:
+    gene = TileGeneration(configure_logging=False)
+    config = await gene.get_config(
+        AnyioPath(str(Path(__file__).parent / "tilegeneration/test-geoms-datasource.yaml")),
+        ignore_error=False,
+    )
+
+    assert "point_datasource" in config.config.get("layers", {})
 
 
 class TestGenerate(CompareCase):

--- a/tilecloud_chain/tests/tilegeneration/geoms/mask.geojson
+++ b/tilecloud_chain/tests/tilegeneration/geoms/mask.geojson
@@ -1,0 +1,21 @@
+{
+    "type": "FeatureCollection",
+    "features": [
+        {
+            "type": "Feature",
+            "properties": {},
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [550000, 170000],
+                        [550000, 180000],
+                        [560000, 180000],
+                        [560000, 170000],
+                        [550000, 170000]
+                    ]
+                ]
+            }
+        }
+    ]
+}

--- a/tilecloud_chain/tests/tilegeneration/test-geoms-datasource.yaml
+++ b/tilecloud_chain/tests/tilegeneration/test-geoms-datasource.yaml
@@ -1,0 +1,26 @@
+grids:
+  swissgrid_5:
+    resolutions: [1000, 500, 250, 100, 50]
+    bbox: [420000, 30000, 900000, 350000]
+    srs: EPSG:21781
+
+caches:
+  local:
+    type: filesystem
+    folder: /tmp/tiles
+
+layers:
+  point_datasource:
+    type: wms
+    url: http://mapserver:8080/
+    layers: point
+    wmts_style: default
+    mime_type: image/png
+    extension: png
+    grid: swissgrid_5
+    geoms:
+      - datasource: geoms/mask.geojson
+
+generation:
+  default_cache: local
+  default_layers: [point_datasource]


### PR DESCRIPTION
## Summary
- extend `layers.<name>.geoms[]` to support a GDAL datasource input via `datasource` in addition to the existing PostGIS `connection` + `sql`
- load datasource geometries through OGR, resolve relative datasource paths from the config file location, and keep existing reprojection/intersection and resolution filtering behavior
- update schema and docs (`USAGE.rst`, `CONFIG.md`, `CHANGELOG.md`) and add tests for datasource path resolution, OGR reading behavior, and datasource-based config validation