### PR TITLE
Fix reprojection and SRID handling for WMTS limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - Add support for `layers.<name>.geoms[].datasource` to load geometry masks from a GDAL datasource (for example a Shapefile), with relative paths resolved from the layer configuration file.
 - Add layer option `geom_filter` (default `true`) to disable the second geometry intersection filter in the generation pipeline when geometry-based seeding is already sufficient.
 - Fix geometry/bbox reprojection edge cases by normalizing bbox axis order before TileMatrixSetLimits and geom filtering, and by honoring PostGIS geometry SRID when present before intersecting with grid extents.
+- Reproject `geoms.datasource` geometries from layer CRS to grid CRS like PostGIS geoms, to avoid empty intersections when layer and grid use different SRS.
 
 Environment variable migration (legacy -> new)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - Speed up `generate-tiles --role=master` queue seeding for metatile layers by using per-row metatile scanline intervals instead of full bounding-pyramid scans, reducing candidate metatiles especially on sparse datasets.
 - Add support for `layers.<name>.geoms[].datasource` to load geometry masks from a GDAL datasource (for example a Shapefile), with relative paths resolved from the layer configuration file.
 - Add layer option `geom_filter` (default `true`) to disable the second geometry intersection filter in the generation pipeline when geometry-based seeding is already sufficient.
+- Fix geometry/bbox reprojection edge cases by normalizing bbox axis order before TileMatrixSetLimits and geom filtering, and by honoring PostGIS geometry SRID when present before intersecting with grid extents.
 
 Environment variable migration (legacy -> new)
 

--- a/tilecloud_chain/USAGE.rst
+++ b/tilecloud_chain/USAGE.rst
@@ -208,6 +208,9 @@ If the SQL geometry column carries an SRID, tilecloud-chain uses that SRID for r
 If no SRID is set (or it is invalid), it falls back to the layer projection. In all cases, bbox and geometry
 bounds are normalized to ``[minx, miny, maxx, maxy]`` before computing intersections and WMTS limits.
 
+For ``geoms.datasource``, geometries are interpreted in the layer projection and are reprojected to the grid
+projection when needed.
+
 When the seed step already limits metatiles with geometries (for example with
 ``generate-tiles --role=master``), you can disable the second geometry intersection
 filter by setting ``geom_filter: false`` in the layer configuration.

--- a/tilecloud_chain/USAGE.rst
+++ b/tilecloud_chain/USAGE.rst
@@ -204,10 +204,13 @@ Example:
 
 It's preferable to use simple geometries, too complex geometries can slow down the generation.
 
+If the SQL geometry column carries an SRID, tilecloud-chain uses that SRID for reprojection to the grid CRS.
+If no SRID is set (or it is invalid), it falls back to the layer projection. In all cases, bbox and geometry
+bounds are normalized to ``[minx, miny, maxx, maxy]`` before computing intersections and WMTS limits.
+
 When the seed step already limits metatiles with geometries (for example with
 ``generate-tiles --role=master``), you can disable the second geometry intersection
 filter by setting ``geom_filter: false`` in the layer configuration.
-
 Legends
 ^^^^^^^
 

--- a/tilecloud_chain/USAGE.rst
+++ b/tilecloud_chain/USAGE.rst
@@ -211,6 +211,7 @@ bounds are normalized to ``[minx, miny, maxx, maxy]`` before computing intersect
 When the seed step already limits metatiles with geometries (for example with
 ``generate-tiles --role=master``), you can disable the second geometry intersection
 filter by setting ``geom_filter: false`` in the layer configuration.
+
 Legends
 ^^^^^^^
 

--- a/tilecloud_chain/__init__.py
+++ b/tilecloud_chain/__init__.py
@@ -1573,7 +1573,7 @@ class TileGeneration:
         grid = get_grid_config(config, layer_name, grid_name)
 
         layer_bbox = normalize_bbox(layer["bbox"]) if "bbox" in layer else None
-        # Repoject the layer bbox
+        # Reproject the layer bbox
         if (
             layer_bbox
             and "proj4_literal" in layer

--- a/tilecloud_chain/__init__.py
+++ b/tilecloud_chain/__init__.py
@@ -843,7 +843,8 @@ def transform_bbox(
         always_xy=True,
     )
 
-    bounds = transformer.transform_bounds(*normalized_bbox)
+    minx, miny, maxx, maxy = normalized_bbox
+    bounds = transformer.transform_bounds(minx, miny, maxx, maxy)
     return normalize_bbox(bounds)
 
 

--- a/tilecloud_chain/__init__.py
+++ b/tilecloud_chain/__init__.py
@@ -1650,7 +1650,14 @@ class TileGeneration:
                 metrics_host = host or self.options.host
                 with _GEOMS_GET_SUMMARY.labels(layer_name, metrics_host).time():
                     if "datasource" in geom_source:
-                        geom = self._load_geom_from_datasource(config.file, geom_source)
+                        geom = self._load_geom_from_datasource(
+                            config.file,
+                            geom_source,
+                            layer_proj4_literal=layer.get("proj4_literal"),
+                            grid_proj4_literal=grid.get("proj4_literal"),
+                            layer_srs=layer.get("srs"),
+                            grid_srs=grid.get("srs"),
+                        )
                     else:
                         geom = self._load_geom_from_postgis(
                             geom_source,
@@ -1723,9 +1730,7 @@ class TileGeneration:
             if grid_proj4_literal is not None
             else source_projection_default
         )
-        destination_srid: int | None = None
-        if grid_srs is not None and grid_srs.startswith("EPSG:"):
-            destination_srid = int(grid_srs.split(":", 1)[1])
+        destination_srid = TileGeneration._parse_epsg(grid_srs)
 
         transformers_by_srid: dict[int | None, pyproj.Transformer] = {}
 
@@ -1804,8 +1809,24 @@ class TileGeneration:
         return not source_projection.equals(destination_projection)
 
     @staticmethod
+    def _parse_epsg(srs: str | None) -> int | None:
+        if srs is None:
+            return None
+        if not srs.upper().startswith("EPSG:"):
+            return None
+        try:
+            return int(srs.split(":", 1)[1])
+        except ValueError:
+            return None
+
+    @staticmethod
     def _load_geom_from_datasource(
-        config_file: Path, geom_source: configuration.LayerGeometry
+        config_file: Path,
+        geom_source: configuration.LayerGeometry,
+        layer_proj4_literal: str | None = None,
+        grid_proj4_literal: str | None = None,
+        layer_srs: str | None = None,
+        grid_srs: str | None = None,
     ) -> BaseGeometry:
         """Load one geometry from a GDAL datasource."""
         datasource = TileGeneration._resolve_gdal_datasource(config_file, geom_source["datasource"])
@@ -1814,7 +1835,29 @@ class TileGeneration:
         if not geometries:
             return GeometryCollection()
 
-        return unary_union(geometries)
+        geom = unary_union(geometries)
+
+        source_projection = pyproj.CRS.from_proj4(layer_proj4_literal) if layer_proj4_literal is not None else None
+        destination_projection = (
+            pyproj.CRS.from_proj4(grid_proj4_literal) if grid_proj4_literal is not None else source_projection
+        )
+
+        if TileGeneration._needs_reprojection(
+            source_projection,
+            destination_projection,
+            source_srid=TileGeneration._parse_epsg(layer_srs),
+            destination_srid=TileGeneration._parse_epsg(grid_srs),
+        ):
+            assert source_projection is not None
+            assert destination_projection is not None
+            transformer = pyproj.Transformer.from_crs(
+                source_projection,
+                destination_projection,
+                always_xy=True,
+            )
+            geom = shapely.ops.transform(transformer.transform, geom)
+
+        return geom
 
     @staticmethod
     def _read_ogr_geometries(datasource: str, sql: str | None) -> list[BaseGeometry]:

--- a/tilecloud_chain/__init__.py
+++ b/tilecloud_chain/__init__.py
@@ -1837,7 +1837,9 @@ class TileGeneration:
 
         geom = unary_union(geometries)
 
-        source_projection = pyproj.CRS.from_proj4(layer_proj4_literal) if layer_proj4_literal is not None else None
+        source_projection = (
+            pyproj.CRS.from_proj4(layer_proj4_literal) if layer_proj4_literal is not None else None
+        )
         destination_projection = (
             pyproj.CRS.from_proj4(grid_proj4_literal) if grid_proj4_literal is not None else source_projection
         )

--- a/tilecloud_chain/__init__.py
+++ b/tilecloud_chain/__init__.py
@@ -1751,13 +1751,11 @@ class TileGeneration:
                             srid = None
 
                     geom_item = loads_wkb(bytes(geom_wkb))
-                    if (
-                        source_projection is not None
-                        and destination_projection is not None
-                        and source_projection != destination_projection
-                    ):
+                    if TileGeneration._needs_reprojection(source_projection, destination_projection):
                         transformer = transformers_by_srid.get(srid)
                         if transformer is None:
+                            assert source_projection is not None
+                            assert destination_projection is not None
                             transformer = pyproj.Transformer.from_crs(
                                 source_projection,
                                 destination_projection,
@@ -1772,6 +1770,22 @@ class TileGeneration:
         finally:
             connection.close()
         return unary_union(geom_list) if geom_list else GeometryCollection()
+
+    @staticmethod
+    def _needs_reprojection(
+        source_projection: pyproj.CRS | None,
+        destination_projection: pyproj.CRS | None,
+    ) -> bool:
+        """Tell if a reprojection is required between source and destination CRS."""
+        if source_projection is None or destination_projection is None:
+            return False
+
+        source_epsg = source_projection.to_epsg()
+        destination_epsg = destination_projection.to_epsg()
+        if source_epsg is not None and destination_epsg is not None and source_epsg == destination_epsg:
+            return False
+
+        return not source_projection.equals(destination_projection)
 
     @staticmethod
     def _load_geom_from_datasource(

--- a/tilecloud_chain/__init__.py
+++ b/tilecloud_chain/__init__.py
@@ -577,7 +577,7 @@ class SparseMetaTileBoundingPyramid(BoundingPyramid):
     def metatilecoords(self, n: int = 8) -> Iterator[TileCoord]:
         """Yield sparse metatile coordinates lazily for configured zoom levels."""
         tile_size = float(self._grid.get("tile_size", configuration.TILE_SIZE_DEFAULT))
-        grid_bbox = [float(v) for v in self._grid["bbox"]]
+        grid_bbox = normalize_bbox(self._grid["bbox"])
 
         for zoom in self._zooms:
             zoom_context = self._get_zoom_context(zoom, n, tile_size, grid_bbox)
@@ -739,7 +739,7 @@ def get_tile_matrix_limits(
         return []
 
     grid = config.config["grids"][grid_name]
-    layer_bbox = [float(value) for value in layer["bbox"]]
+    layer_bbox = normalize_bbox(layer["bbox"])
     if (
         "proj4_literal" in layer
         and "proj4_literal" in grid
@@ -747,7 +747,7 @@ def get_tile_matrix_limits(
     ):
         layer_bbox = transform_bbox(layer["proj4_literal"], grid["proj4_literal"], layer_bbox)
 
-    grid_bbox = [float(value) for value in grid["bbox"]]
+    grid_bbox = normalize_bbox(grid["bbox"])
     min_x = max(layer_bbox[0], grid_bbox[0])
     min_y = max(layer_bbox[1], grid_bbox[1])
     max_x = min(layer_bbox[2], grid_bbox[2])
@@ -803,7 +803,22 @@ def get_proj4_literal(srs: int) -> str:
     return proj4_literals.get(srs, f"+init=EPSG:{srs}")
 
 
-def transform_bbox(proj4_literals_src: str, proj4_literals_dst: str, bbox: list[float]) -> list[float]:
+def normalize_bbox(
+    bbox: list[int | float] | tuple[int | float, int | float, int | float, int | float],
+) -> list[float]:
+    """Normalize a bounding box to [minx, miny, maxx, maxy]."""
+    minx = min(float(bbox[0]), float(bbox[2]))
+    miny = min(float(bbox[1]), float(bbox[3]))
+    maxx = max(float(bbox[0]), float(bbox[2]))
+    maxy = max(float(bbox[1]), float(bbox[3]))
+    return [minx, miny, maxx, maxy]
+
+
+def transform_bbox(
+    proj4_literals_src: str,
+    proj4_literals_dst: str,
+    bbox: list[int | float] | tuple[int | float, int | float, int | float, int | float],
+) -> list[float]:
     """
     Transform a bounding box from source projection to destination projection.
 
@@ -816,14 +831,20 @@ def transform_bbox(proj4_literals_src: str, proj4_literals_dst: str, bbox: list[
     -------
         Transformed bounding box as [xmin, ymin, xmax, ymax]
     """
+    normalized_bbox = normalize_bbox(bbox)
+    if proj4_literals_src == proj4_literals_dst:
+        return normalized_bbox
+
     source_projection = pyproj.CRS.from_proj4(proj4_literals_src)
     dest_projection = pyproj.CRS.from_proj4(proj4_literals_dst)
-    transformer = pyproj.Transformer.from_crs(source_projection, dest_projection)
+    transformer = pyproj.Transformer.from_crs(
+        source_projection,
+        dest_projection,
+        always_xy=True,
+    )
 
-    point_1 = transformer.transform(bbox[0], bbox[1])
-    point_2 = transformer.transform(bbox[2], bbox[3])
-
-    return [point_1[0], point_1[1], point_2[0], point_2[1]]
+    bounds = transformer.transform_bounds(*normalized_bbox)
+    return normalize_bbox(bounds)
 
 
 class TileGeneration:
@@ -1521,7 +1542,10 @@ class TileGeneration:
         tilegrid = FreeTileGrid(
             resolutions=[r * scale for r in grid["resolutions"]],
             scale=scale,
-            max_extent=cast("tuple[int, int, int, int] | tuple[float, float, float, float]", grid["bbox"]),
+            max_extent=cast(
+                "tuple[int, int, int, int] | tuple[float, float, float, float]",
+                normalize_bbox(grid["bbox"]),
+            ),
             tile_size=grid.get("tile_size", configuration.TILE_SIZE_DEFAULT),
         )
 
@@ -1547,7 +1571,7 @@ class TileGeneration:
 
         grid = get_grid_config(config, layer_name, grid_name)
 
-        layer_bbox: list[int | float] | None = layer.get("bbox")
+        layer_bbox = normalize_bbox(layer["bbox"]) if "bbox" in layer else None
         # Repoject the layer bbox
         if (
             layer_bbox
@@ -1572,7 +1596,7 @@ class TileGeneration:
                     (layer_bbox[1] + layer_bbox[3]) / 2,
                 ]
             )
-            grid_bbox = grid["bbox"]
+            grid_bbox = normalize_bbox(grid["bbox"])
             diff = [position[0] - grid_bbox[0], position[1] - grid_bbox[1]]
             resolution = grid["resolutions"][self.options.zoom[0]]
             mt_to_m = (
@@ -1601,11 +1625,11 @@ class TileGeneration:
             ):
                 extent = transform_bbox(layer["proj4_literal"], grid["proj4_literal"], self.options.bbox)
             else:
-                extent = self.options.bbox
+                extent = normalize_bbox(self.options.bbox)
         elif layer_bbox is not None:
             extent = layer_bbox
         else:
-            extent = grid["bbox"]
+            extent = normalize_bbox(grid["bbox"])
 
         geoms: dict[str | int, BaseGeometry] = {}
         if extent:
@@ -1627,20 +1651,12 @@ class TileGeneration:
                     if "datasource" in geom_source:
                         geom = self._load_geom_from_datasource(config.file, geom_source)
                     else:
-                        geom = self._load_geom_from_postgis(geom_source)
-
-                    # Reproject the geometry if needed
-                    if (
-                        "proj4_literal" in layer
-                        and "proj4_literal" in grid
-                        and layer["proj4_literal"] != grid["proj4_literal"]
-                    ):
-                        # Create transformer from layer to grid projection
-                        source_projection = pyproj.CRS.from_proj4(layer["proj4_literal"])
-                        dest_projection = pyproj.CRS.from_proj4(grid["proj4_literal"])
-                        transformer = pyproj.Transformer.from_crs(source_projection, dest_projection)
-                        # Transform the geometry
-                        geom = shapely.ops.transform(transformer.transform, geom)
+                        geom = self._load_geom_from_postgis(
+                            geom_source,
+                            layer_proj4_literal=layer.get("proj4_literal"),
+                            grid_proj4_literal=grid.get("proj4_literal"),
+                            layer_name=layer_name,
+                        )
 
                     if extent:
                         geom = geom.intersection(
@@ -1689,21 +1705,72 @@ class TileGeneration:
         return resolved_datasource
 
     @staticmethod
-    def _load_geom_from_postgis(geom_source: configuration.LayerGeometry) -> BaseGeometry:
+    def _load_geom_from_postgis(
+        geom_source: configuration.LayerGeometry,
+        layer_proj4_literal: str | None = None,
+        grid_proj4_literal: str | None = None,
+        layer_name: str | None = None,
+    ) -> BaseGeometry:
         """Load one geometry from a PostGIS source."""
+        source_projection_default = (
+            pyproj.CRS.from_proj4(layer_proj4_literal) if layer_proj4_literal is not None else None
+        )
+        destination_projection = (
+            pyproj.CRS.from_proj4(grid_proj4_literal)
+            if grid_proj4_literal is not None
+            else source_projection_default
+        )
+        transformers_by_srid: dict[int | None, pyproj.Transformer] = {}
+
         connection = psycopg2.connect(geom_source["connection"])
         try:
             cursor = connection.cursor()
             try:
-                sql = f"SELECT ST_AsBinary(geom) FROM (SELECT {geom_source['sql']}) AS g"  # nosec # noqa: S608
+                sql = f"SELECT ST_AsBinary(geom), ST_SRID(geom) FROM (SELECT {geom_source['sql']}) AS g"  # nosec # noqa: S608
                 _LOGGER.info("Execute SQL: %s.", sql)
                 cursor.execute(sql)
-                geom_list = [loads_wkb(bytes(result[0])) for result in cursor.fetchall()]
+                geom_list = []
+                for geom_wkb, geom_srid in cursor.fetchall():
+                    if geom_wkb is None:
+                        continue
+
+                    source_projection = source_projection_default
+                    srid: int | None = None
+                    if geom_srid is not None and int(geom_srid) > 0:
+                        srid = int(geom_srid)
+                        try:
+                            source_projection = pyproj.CRS.from_epsg(srid)
+                        except pyproj.exceptions.CRSError:
+                            _LOGGER.warning(
+                                "Unsupported geometry SRID '%s' on layer '%s', fallback to layer projection.",
+                                srid,
+                                layer_name or "-",
+                            )
+                            source_projection = source_projection_default
+                            srid = None
+
+                    geom_item = loads_wkb(bytes(geom_wkb))
+                    if (
+                        source_projection is not None
+                        and destination_projection is not None
+                        and source_projection != destination_projection
+                    ):
+                        transformer = transformers_by_srid.get(srid)
+                        if transformer is None:
+                            transformer = pyproj.Transformer.from_crs(
+                                source_projection,
+                                destination_projection,
+                                always_xy=True,
+                            )
+                            transformers_by_srid[srid] = transformer
+                        geom_item = shapely.ops.transform(transformer.transform, geom_item)
+
+                    geom_list.append(geom_item)
             finally:
                 cursor.close()
         finally:
             connection.close()
-        return unary_union(geom_list)
+        return unary_union(geom_list) if geom_list else GeometryCollection()
 
     @staticmethod
     def _load_geom_from_datasource(

--- a/tilecloud_chain/__init__.py
+++ b/tilecloud_chain/__init__.py
@@ -1656,6 +1656,7 @@ class TileGeneration:
                             geom_source,
                             layer_proj4_literal=layer.get("proj4_literal"),
                             grid_proj4_literal=grid.get("proj4_literal"),
+                            grid_srs=grid.get("srs"),
                             layer_name=layer_name,
                         )
 
@@ -1710,6 +1711,7 @@ class TileGeneration:
         geom_source: configuration.LayerGeometry,
         layer_proj4_literal: str | None = None,
         grid_proj4_literal: str | None = None,
+        grid_srs: str | None = None,
         layer_name: str | None = None,
     ) -> BaseGeometry:
         """Load one geometry from a PostGIS source."""
@@ -1721,6 +1723,10 @@ class TileGeneration:
             if grid_proj4_literal is not None
             else source_projection_default
         )
+        destination_srid: int | None = None
+        if grid_srs is not None and grid_srs.startswith("EPSG:"):
+            destination_srid = int(grid_srs.split(":", 1)[1])
+
         transformers_by_srid: dict[int | None, pyproj.Transformer] = {}
 
         connection = psycopg2.connect(geom_source["connection"])
@@ -1751,7 +1757,12 @@ class TileGeneration:
                             srid = None
 
                     geom_item = loads_wkb(bytes(geom_wkb))
-                    if TileGeneration._needs_reprojection(source_projection, destination_projection):
+                    if TileGeneration._needs_reprojection(
+                        source_projection,
+                        destination_projection,
+                        source_srid=srid,
+                        destination_srid=destination_srid,
+                    ):
                         transformer = transformers_by_srid.get(srid)
                         if transformer is None:
                             assert source_projection is not None
@@ -1775,9 +1786,14 @@ class TileGeneration:
     def _needs_reprojection(
         source_projection: pyproj.CRS | None,
         destination_projection: pyproj.CRS | None,
+        source_srid: int | None = None,
+        destination_srid: int | None = None,
     ) -> bool:
         """Tell if a reprojection is required between source and destination CRS."""
         if source_projection is None or destination_projection is None:
+            return False
+
+        if source_srid is not None and destination_srid is not None and source_srid == destination_srid:
             return False
 
         source_epsg = source_projection.to_epsg()

--- a/tilecloud_chain/tests/test_generate.py
+++ b/tilecloud_chain/tests/test_generate.py
@@ -322,6 +322,31 @@ def test_load_geom_from_datasource_with_sql(monkeypatch: pytest.MonkeyPatch) -> 
     assert geom.is_empty
 
 
+def test_load_geom_from_datasource_reprojects_to_grid(monkeypatch: pytest.MonkeyPatch) -> None:
+    source_projection = get_proj4_literal(21781)
+    destination_projection = get_proj4_literal(2056)
+    source_geom = box(550100.0, 170100.0, 550200.0, 170200.0)
+
+    def _read_ogr_geometries(_datasource: str, _sql: str | None) -> list[Any]:
+        return [source_geom]
+
+    monkeypatch.setattr(TileGeneration, "_read_ogr_geometries", _read_ogr_geometries)
+
+    geom = TileGeneration._load_geom_from_datasource(
+        AnyioPath("/tmp/tilegeneration/config.yaml"),
+        {"datasource": "geoms/mask.geojson"},
+        layer_proj4_literal=source_projection,
+        grid_proj4_literal=destination_projection,
+        layer_srs="EPSG:21781",
+        grid_srs="EPSG:2056",
+    )
+
+    assert geom.bounds == pytest.approx(
+        tuple(transform_bbox(source_projection, destination_projection, source_geom.bounds)),
+        abs=1e-6,
+    )
+
+
 def test_get_geoms_from_datasource(monkeypatch: pytest.MonkeyPatch) -> None:
     read_args: tuple[str, str | None] | None = None
 
@@ -627,7 +652,7 @@ def test_get_geoms_respects_geometry_srid(monkeypatch: pytest.MonkeyPatch) -> No
     geoms = gene.get_geoms(config, "layer", "grid_2056")
 
     assert not geoms[0].is_empty
-    assert geoms[0].equals(geom)
+    assert geoms[0].symmetric_difference(geom).area < 1e-9
 
 
 class TestGenerate(CompareCase):

--- a/tilecloud_chain/tests/test_generate.py
+++ b/tilecloud_chain/tests/test_generate.py
@@ -16,6 +16,7 @@ from shapely.geometry import box
 from testfixtures import LogCapture
 from tilecloud.store.redis import RedisTileStore
 
+import tilecloud_chain
 from tilecloud_chain import (
     DatedConfig,
     IntersectGeometryFilter,
@@ -23,6 +24,10 @@ from tilecloud_chain import (
     TileGeneration,
     controller,
     generate,
+    get_proj4_literal,
+    get_tile_matrix_limits,
+    normalize_bbox,
+    transform_bbox,
 )
 from tilecloud_chain import configuration as tcc_configuration
 from tilecloud_chain.settings import settings
@@ -494,6 +499,135 @@ def test_intersect_geometry_filter_can_be_disabled_per_layer() -> None:
     assert filter_.filter_tilecoord(cast("Any", config), Mock(), "point", "swissgrid") is True
     gene.get_grid.assert_not_called()
     gene.get_geoms.assert_not_called()
+
+
+def test_normalize_bbox() -> None:
+    assert normalize_bbox([6, 2, 1, 5]) == [1.0, 2.0, 6.0, 5.0]
+
+
+def test_transform_bbox_normalizes_reversed_input() -> None:
+    source = "+proj=longlat +datum=WGS84 +no_defs"
+    destination = "+proj=merc +a=6378137 +b=6378137 +lat_ts=0 +lon_0=0 +k=1 +units=m +no_defs"
+
+    transformed = transform_bbox(source, destination, [8.0, 47.0, 7.5, 46.5])
+
+    assert transformed[0] < transformed[2]
+    assert transformed[1] < transformed[3]
+
+
+def test_get_tile_matrix_limits_with_reversed_bbox() -> None:
+    config = DatedConfig(
+        cast(
+            "tcc_configuration.Configuration",
+            {
+                "layers": {
+                    "layer": {
+                        "bbox": [560000.0, 180000.0, 550000.0, 170000.0],
+                    },
+                },
+                "grids": {
+                    "grid": {
+                        "bbox": [420000.0, 30000.0, 900000.0, 350000.0],
+                        "resolutions": [100.0],
+                        "tile_size": 256,
+                    },
+                },
+            },
+        ),
+        0,
+        AnyioPath("config.yaml"),
+    )
+
+    limits = get_tile_matrix_limits(config, "layer", "grid")
+
+    assert limits == [
+        {
+            "tile_matrix": "0",
+            "min_tile_row": 6,
+            "max_tile_row": 7,
+            "min_tile_col": 5,
+            "max_tile_col": 5,
+        },
+    ]
+
+
+def test_get_geoms_respects_geometry_srid(monkeypatch: pytest.MonkeyPatch) -> None:
+    class FakeCursor:
+        def __init__(self, rows: list[tuple[bytes, int]]) -> None:
+            self.rows = rows
+
+        def execute(self, _sql: str) -> None:
+            return
+
+        def fetchall(self) -> list[tuple[bytes, int]]:
+            return self.rows
+
+        def close(self) -> None:
+            return
+
+    class FakeConnection:
+        def __init__(self, rows: list[tuple[bytes, int]]) -> None:
+            self.rows = rows
+
+        def cursor(self) -> FakeCursor:
+            return FakeCursor(self.rows)
+
+        def close(self) -> None:
+            return
+
+    layer_projection = get_proj4_literal(21781)
+    grid_projection = get_proj4_literal(2056)
+    transformed_layer_bbox = transform_bbox(layer_projection, grid_projection, [550000, 170000, 560000, 180000])
+    geom = box(
+        transformed_layer_bbox[0] + 500,
+        transformed_layer_bbox[1] + 500,
+        transformed_layer_bbox[0] + 1000,
+        transformed_layer_bbox[1] + 1000,
+    )
+    rows = [(geom.wkb, 2056)]
+
+    monkeypatch.setattr(
+        tilecloud_chain.psycopg2,
+        "connect",
+        lambda _connection: FakeConnection(rows),
+    )
+
+    gene = TileGeneration(options=Namespace(host="localhost"), configure_logging=False)
+    config = DatedConfig(
+        cast(
+            "tcc_configuration.Configuration",
+            {
+                "layers": {
+                    "layer": {
+                        "bbox": [550000.0, 170000.0, 560000.0, 180000.0],
+                        "proj4_literal": layer_projection,
+                        "grids": ["grid_2056"],
+                        "geoms": [
+                            {
+                                "sql": "the_geom AS geom FROM tests.point",
+                                "connection": "postgresql://dummy",
+                            },
+                        ],
+                    },
+                },
+                "grids": {
+                    "grid_2056": {
+                        "bbox": [2420000.0, 1030000.0, 2900000.0, 1350000.0],
+                        "resolutions": [1000.0],
+                        "tile_size": 256,
+                        "proj4_literal": grid_projection,
+                    },
+                },
+            },
+        ),
+        0,
+        AnyioPath("config.yaml"),
+    )
+
+    geoms = gene.get_geoms(config, "layer", "grid_2056")
+
+    assert not geoms[0].is_empty
+    assert geoms[0].bounds == geom.bounds
 
 
 class TestGenerate(CompareCase):

--- a/tilecloud_chain/tests/test_generate.py
+++ b/tilecloud_chain/tests/test_generate.py
@@ -652,7 +652,7 @@ def test_get_geoms_respects_geometry_srid(monkeypatch: pytest.MonkeyPatch) -> No
     geoms = gene.get_geoms(config, "layer", "grid_2056")
 
     assert not geoms[0].is_empty
-    assert geoms[0].symmetric_difference(geom).area < 1e-9
+    assert geoms[0].symmetric_difference(geom).area < 1e-5
 
 
 class TestGenerate(CompareCase):

--- a/tilecloud_chain/tests/test_generate.py
+++ b/tilecloud_chain/tests/test_generate.py
@@ -627,7 +627,7 @@ def test_get_geoms_respects_geometry_srid(monkeypatch: pytest.MonkeyPatch) -> No
     geoms = gene.get_geoms(config, "layer", "grid_2056")
 
     assert not geoms[0].is_empty
-    assert geoms[0].bounds == geom.bounds
+    assert geoms[0].equals_exact(geom, 1e-8)
 
 
 class TestGenerate(CompareCase):

--- a/tilecloud_chain/tests/test_generate.py
+++ b/tilecloud_chain/tests/test_generate.py
@@ -627,7 +627,7 @@ def test_get_geoms_respects_geometry_srid(monkeypatch: pytest.MonkeyPatch) -> No
     geoms = gene.get_geoms(config, "layer", "grid_2056")
 
     assert not geoms[0].is_empty
-    assert geoms[0].equals_exact(geom, 1e-8)
+    assert geoms[0].equals(geom)
 
 
 class TestGenerate(CompareCase):


### PR DESCRIPTION
## Summary
- Normalize all bboxes to `[minx, miny, maxx, maxy]` before tile limit and geometry filtering computations.
- Use `transform_bounds` with `always_xy=True` for bbox reprojection to avoid axis-order and corner-only transform issues.
- Respect PostGIS geometry SRID when present by querying `ST_SRID(geom)` and reprojecting each geometry to the grid CRS before intersections.
- Add targeted unit tests for bbox normalization, reprojection, TileMatrixSetLimits, and SRID-aware geometry loading.
- Update user-facing docs in `tilecloud_chain/USAGE.rst` and `CHANGELOG.md`.