### PR TITLE
Improve admin error message and ETA wording

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@
 - Add layer option `geom_filter` (default `true`) to disable the second geometry intersection filter in the generation pipeline when geometry-based seeding is already sufficient.
 - Fix geometry/bbox reprojection edge cases by normalizing bbox axis order before TileMatrixSetLimits and geom filtering, and by honoring PostGIS geometry SRID when present before intersecting with grid extents.
 - Reproject `geoms.datasource` geometries from layer CRS to grid CRS like PostGIS geoms, to avoid empty intersections when layer and grid use different SRS.
-- Show a clear admin error message when a generation command fails before producing output (for example an unknown grid), and clarify PostgreSQL job ETA text with explicit units like `2 days 2 hours`.
+- Show a clear admin error message when a generation command fails before producing output (for example, an unknown grid), and clarify PostgreSQL job ETA text with explicit units like `2 days 2 hours`.
 
 Environment variable migration (legacy -> new)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - Add layer option `geom_filter` (default `true`) to disable the second geometry intersection filter in the generation pipeline when geometry-based seeding is already sufficient.
 - Fix geometry/bbox reprojection edge cases by normalizing bbox axis order before TileMatrixSetLimits and geom filtering, and by honoring PostGIS geometry SRID when present before intersecting with grid extents.
 - Reproject `geoms.datasource` geometries from layer CRS to grid CRS like PostGIS geoms, to avoid empty intersections when layer and grid use different SRS.
+- Show a clear admin error message when a generation command fails before producing output (for example an unknown grid), and clarify PostgreSQL job ETA text with explicit units like `2 days 2 hours`.
 
 Environment variable migration (legacy -> new)
 

--- a/tilecloud_chain/store/postgresql.py
+++ b/tilecloud_chain/store/postgresql.py
@@ -124,7 +124,9 @@ def _format_duration(seconds: int) -> str:
     hours, rem = divmod(rem, 3600)
     minutes, _secs = divmod(rem, 60)
     if days > 0:
-        return f"{days} days {hours}"
+        day_label = "day" if days == 1 else "days"
+        hour_label = "hour" if hours == 1 else "hours"
+        return f"{days} {day_label} {hours} {hour_label}"
     if hours > 0:
         return f"{hours}:{minutes:02}"
     return f"{minutes} minutes"

--- a/tilecloud_chain/tests/test_admin.py
+++ b/tilecloud_chain/tests/test_admin.py
@@ -28,3 +28,31 @@ async def test_run_keeps_command_output_on_error() -> None:
 
     assert result["error"] is True
     assert result["out"] == "A detailed error message from command output"
+
+
+@pytest.mark.asyncio
+async def test_run_escapes_fallback_exception_message() -> None:
+    async def main(_args: list[str], _out: IO[str]) -> None:
+        raise ValueError("<script>alert('xss')</script>")
+
+    result: dict[str, Any] = {}
+    await admin._run(["generate-tiles"], main, result)
+
+    assert result["error"] is True
+    assert "<script>" not in result["out"]
+    assert "&lt;script&gt;" in result["out"]
+
+
+@pytest.mark.asyncio
+async def test_run_truncates_fallback_exception_message(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def main(_args: list[str], _out: IO[str]) -> None:
+        raise ValueError("x" * 200)
+
+    monkeypatch.setattr(admin.settings, "max_output_length", 40)
+
+    result: dict[str, Any] = {}
+    await admin._run(["generate-tiles"], main, result)
+
+    assert result["error"] is True
+    assert result["out"].endswith("\n...")
+    assert len(result["out"]) <= 41

--- a/tilecloud_chain/tests/test_admin.py
+++ b/tilecloud_chain/tests/test_admin.py
@@ -1,4 +1,3 @@
-from collections.abc import Awaitable
 from typing import IO, Any
 
 import pytest

--- a/tilecloud_chain/tests/test_admin.py
+++ b/tilecloud_chain/tests/test_admin.py
@@ -14,7 +14,7 @@ async def test_run_returns_exception_message_when_output_is_empty() -> None:
     await admin._run(["generate-tiles", "--grid=unknown_grid"], main, result)
 
     assert result["error"] is True
-    assert result["out"] == "Error while running the command: Invalid grid 'unknown_grid'"
+    assert result["out"] == "Error while running the command: Invalid grid &#x27;unknown_grid&#x27;"
 
 
 @pytest.mark.asyncio

--- a/tilecloud_chain/tests/test_admin.py
+++ b/tilecloud_chain/tests/test_admin.py
@@ -1,0 +1,31 @@
+from collections.abc import Awaitable
+from typing import IO, Any
+
+import pytest
+
+from tilecloud_chain.views import admin
+
+
+@pytest.mark.asyncio
+async def test_run_returns_exception_message_when_output_is_empty() -> None:
+    async def main(_args: list[str], _out: IO[str]) -> None:
+        raise ValueError("Invalid grid 'unknown_grid'")
+
+    result: dict[str, Any] = {}
+    await admin._run(["generate-tiles", "--grid=unknown_grid"], main, result)
+
+    assert result["error"] is True
+    assert result["out"] == "Error while running the command: Invalid grid 'unknown_grid'"
+
+
+@pytest.mark.asyncio
+async def test_run_keeps_command_output_on_error() -> None:
+    async def main(_args: list[str], out: IO[str]) -> None:
+        out.write("A detailed error message from command output")
+        raise RuntimeError("should not replace output")
+
+    result: dict[str, Any] = {}
+    await admin._run(["generate-tiles"], main, result)
+
+    assert result["error"] is True
+    assert result["out"] == "A detailed error message from command output"

--- a/tilecloud_chain/tests/test_postgresql.py
+++ b/tilecloud_chain/tests/test_postgresql.py
@@ -22,6 +22,7 @@ from tilecloud_chain.store.postgresql import (
     Job,
     PostgresqlTileStore,
     Queue,
+    _format_duration,
     get_postgresql_queue_store,
 )
 
@@ -167,6 +168,14 @@ async def test_get_status_with_eta_when_remaining_exceeds_total(
     statuses = await tilestore.get_status(Path("config.yaml"))
     status = next(status for status in statuses if status[0].id == job_id)
     assert status[3] is None
+
+
+def test_format_duration_days_hours_text() -> None:
+    assert _format_duration(2 * 86400 + 2 * 3600) == "2 days 2 hours"
+
+
+def test_format_duration_one_day_one_hour_text() -> None:
+    assert _format_duration(86400 + 3600) == "1 day 1 hour"
 
 
 @pytest.mark.asyncio

--- a/tilecloud_chain/views/admin.py
+++ b/tilecloud_chain/views/admin.py
@@ -484,6 +484,9 @@ async def _run(
     )
     if error and not parsed_out:
         detail = f": {error_detail}" if error_detail else ""
-        parsed_out = f"Error while running the command{detail}"
+        parsed_out = _format_output(
+            f"Error while running the command{detail}",
+            settings.max_output_length,
+        )
     return_dict["out"] = parsed_out
     return_dict["error"] = error

--- a/tilecloud_chain/views/admin.py
+++ b/tilecloud_chain/views/admin.py
@@ -483,7 +483,7 @@ async def _run(
         "<br />".join(_parse_stdout(out.getvalue())),
         settings.max_output_length,
     )
-    if error and not parsed_out:
+    if error and not parsed_out.strip():
         detail = f": {html.escape(error_detail)}" if error_detail else ""
         parsed_out = _format_output(
             f"Error while running the command{detail}",

--- a/tilecloud_chain/views/admin.py
+++ b/tilecloud_chain/views/admin.py
@@ -469,15 +469,21 @@ async def _run(
 ) -> None:
     display_command = shlex.join(final_command)
     error = False
+    error_detail: str | None = None
     out = io.StringIO()
     try:
         _LOG.debug("Running the command `%s` using the function directly", display_command)
         await main(final_command, out)
-    except Exception:  # noqa: BLE001
+    except Exception as exc:  # noqa: BLE001
         _LOG.exception("Error while running the command `%s`", display_command)
         error = True
-    return_dict["out"] = _format_output(
+        error_detail = str(exc)
+    parsed_out = _format_output(
         "<br />".join(_parse_stdout(out.getvalue())),
         settings.max_output_length,
     )
+    if error and not parsed_out:
+        detail = f": {error_detail}" if error_detail else ""
+        parsed_out = f"Error while running the command{detail}"
+    return_dict["out"] = parsed_out
     return_dict["error"] = error

--- a/tilecloud_chain/views/admin.py
+++ b/tilecloud_chain/views/admin.py
@@ -27,6 +27,7 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import asyncio
+import html
 import io
 import json
 import logging
@@ -483,7 +484,7 @@ async def _run(
         settings.max_output_length,
     )
     if error and not parsed_out:
-        detail = f": {error_detail}" if error_detail else ""
+        detail = f": {html.escape(error_detail)}" if error_detail else ""
         parsed_out = _format_output(
             f"Error while running the command{detail}",
             settings.max_output_length,


### PR DESCRIPTION
## What
- show a user-friendly error message in admin when a command fails before producing output (for example unknown grid)
- make PostgreSQL ETA formatting explicit with units (for example 2 days 2 hours)
- add tests for admin run error-output behavior and duration formatting
- update changelog
