### PR TITLE
Fix multigrid cache key collisions

### DIFF
--- a/tilecloud_chain/internal_mapcache.py
+++ b/tilecloud_chain/internal_mapcache.py
@@ -123,6 +123,7 @@ class RedisStore(AsyncTileStore):
             self._prefix,
             tile.metadata["config_file"],
             tile.metadata["layer"],
+            tile.metadata["grid"],
             tile.tilecoord.z,
             tile.tilecoord.x,
             tile.tilecoord.y,

--- a/tilecloud_chain/server.py
+++ b/tilecloud_chain/server.py
@@ -231,7 +231,7 @@ class Server:
         """Initialize."""
         self.filter_cache: dict[Path, dict[str, DatedFilter]] = {}
         self.s3_client_cache: dict[str, botocore.client.S3] = {}  # pylint: disable=no-member
-        self.store_cache: dict[Path, dict[str, DatedStore]] = {}
+        self.store_cache: dict[tuple[Path, str, str], DatedStore] = {}
 
     @staticmethod
     def get_expires_hours(config: tilecloud_chain.DatedConfig) -> float:
@@ -310,7 +310,8 @@ class Server:
         grid_name: str,
     ) -> AsyncTileStore | None:
         """Get the store from the config."""
-        dated_store = self.store_cache.get(config.file, {}).get(layer_name)
+        cache_key = (config.file, layer_name, grid_name)
+        dated_store = self.store_cache.get(cache_key)
 
         if dated_store is not None and dated_store.mtime == config.mtime:
             return dated_store.store
@@ -326,7 +327,7 @@ class Server:
         )
         if store is None:
             return None
-        self.store_cache.setdefault(config.file, {})[layer_name] = DatedStore(store, config.mtime)
+        self.store_cache[cache_key] = DatedStore(store, config.mtime)
         return store
 
     @staticmethod

--- a/tilecloud_chain/tests/test_serve.py
+++ b/tilecloud_chain/tests/test_serve.py
@@ -4,12 +4,14 @@ from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from tilecloud import Tile, TileCoord
 import yaml
 from anyio import Path as AnyioPath
 from fastapi import HTTPException
 from testfixtures import LogCapture
 
 from tilecloud_chain import DatedConfig, TileGeneration, generate, server
+from tilecloud_chain.internal_mapcache import RedisStore
 from tilecloud_chain.tests import CompareCase
 
 _CAPABILITIES = (
@@ -1263,3 +1265,83 @@ class TestServe(CompareCase):
                 regex=True,
             )
             log_capture.check()
+
+    @pytest.mark.asyncio
+    async def test_multigrid_store_cache_isolated_by_grid(self) -> None:
+        server._PYRAMID_SERVER = None
+        server.server.store_cache = {}
+        server._TILEGENERATION = TileGeneration(
+            config_file=AnyioPath("tilegeneration/test-multi-grid.yaml"),
+            configure_logging=False,
+        )
+
+        with Path("tilegeneration/test-multi-grid.yaml").open() as f:
+            config = DatedConfig(
+                config=yaml.safe_load(f),
+                mtime=Path("tilegeneration/test-multi-grid.yaml").stat().st_mtime,
+                file=AnyioPath("tilegeneration/test-multi-grid.yaml"),
+            )
+
+        base_params = {
+            "SERVICE": "WMTS",
+            "VERSION": "1.0.0",
+            "REQUEST": "GetTile",
+            "FORMAT": "image/png",
+            "LAYER": "all",
+            "STYLE": "default",
+            "TILEMATRIX": "0",
+            "TILEROW": "0",
+            "TILECOL": "0",
+            "DATE": "2012",
+        }
+
+        with (
+            patch("tilecloud_chain.IntersectGeometryFilter.filter_tilecoord", return_value=True),
+            patch.object(server._TILEGENERATION, "get_store", new_callable=AsyncMock) as mock_get_store,
+        ):
+            mock_store = AsyncMock()
+            mock_store.get_one.return_value = None
+            mock_get_store.return_value = mock_store
+
+            params = base_params | {"TILEMATRIXSET": "swissgrid_2056"}
+            with pytest.raises(HTTPException) as response:
+                await server.server.serve(params, config, "localhost", None)
+            assert response.value.status_code == 204
+
+            params = base_params | {"TILEMATRIXSET": "swissgrid_21781"}
+            with pytest.raises(HTTPException) as response:
+                await server.server.serve(params, config, "localhost", None)
+            assert response.value.status_code == 204
+
+            assert mock_get_store.await_count == 2
+            assert mock_get_store.await_args_list[0].args[3] == "swissgrid_2056"
+            assert mock_get_store.await_args_list[1].args[3] == "swissgrid_21781"
+
+    def test_mapcache_redis_key_includes_grid(self) -> None:
+        store = MagicMock()
+        store._prefix = "test-prefix"
+        tile_2056 = Tile(
+            TileCoord(0, 1, 2),
+            metadata={
+                "config_file": "tilegeneration/test-multi-grid.yaml",
+                "layer": "all",
+                "grid": "swissgrid_2056",
+                "dimension_DATE": "2012",
+            },
+        )
+        tile_21781 = Tile(
+            TileCoord(0, 1, 2),
+            metadata={
+                "config_file": "tilegeneration/test-multi-grid.yaml",
+                "layer": "all",
+                "grid": "swissgrid_21781",
+                "dimension_DATE": "2012",
+            },
+        )
+
+        key_2056 = RedisStore._get_key(store, tile_2056)
+        key_21781 = RedisStore._get_key(store, tile_21781)
+
+        assert key_2056 != key_21781
+        assert "swissgrid_2056" in key_2056
+        assert "swissgrid_21781" in key_21781

--- a/tilecloud_chain/tests/test_serve.py
+++ b/tilecloud_chain/tests/test_serve.py
@@ -1281,6 +1281,7 @@ class TestServe(CompareCase):
                 mtime=Path("tilegeneration/test-multi-grid.yaml").stat().st_mtime,
                 file=AnyioPath("tilegeneration/test-multi-grid.yaml"),
             )
+        config.config.setdefault("server", {})
 
         base_params = {
             "SERVICE": "WMTS",

--- a/tilecloud_chain/tests/test_serve.py
+++ b/tilecloud_chain/tests/test_serve.py
@@ -4,11 +4,11 @@ from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from tilecloud import Tile, TileCoord
 import yaml
 from anyio import Path as AnyioPath
 from fastapi import HTTPException
 from testfixtures import LogCapture
+from tilecloud import Tile, TileCoord
 
 from tilecloud_chain import DatedConfig, TileGeneration, generate, server
 from tilecloud_chain.internal_mapcache import RedisStore


### PR DESCRIPTION
## What
- isolate server tile store cache by (config_file, layer, grid) instead of (config_file, layer)
- include grid in internal Redis mapcache key composition
- add regression tests for multigrid store isolation and Redis key uniqueness

## Why
When a layer is available on multiple grids, cache keys that omit the grid can return tiles from another TileMatrixSet.

## Notes
- keeps branch naming rule (no slash)
- no user-facing API changes