### PR TITLE
Reduce tile generation overhead in MultiAction and HashDropper

### DIFF
--- a/tilecloud_chain/__init__.py
+++ b/tilecloud_chain/__init__.py
@@ -1453,17 +1453,46 @@ class TileGeneration:
             async def _async_metatile() -> AsyncIterator[Tile]:
                 yield metatile
 
+            start_split = time.perf_counter()
             substream = store.get(_async_metatile())
             if getattr(self.options, "role", "") == "hash":
                 tile = await anext(substream)
                 assert tile is not None
+                split_duration = time.perf_counter() - start_split
+                _LOGGER.debug(
+                    "[%s] metatile split fetch in %.6fs",
+                    metatile.tilecoord,
+                    split_duration,
+                )
+                start_pipeline = time.perf_counter()
                 await run(tile)
+                pipeline_duration = time.perf_counter() - start_pipeline
+                _LOGGER.debug(
+                    "[%s] metatile split pipeline in %.6fs",
+                    metatile.tilecoord,
+                    pipeline_duration,
+                )
             else:
                 tasks = []
                 async for tile in substream:
                     assert tile is not None
                     tasks.append(run(tile))
+                split_duration = time.perf_counter() - start_split
+                _LOGGER.debug(
+                    "[%s] metatile split fetch in %.6fs (%d tiles)",
+                    metatile.tilecoord,
+                    split_duration,
+                    len(tasks),
+                )
+                start_pipeline = time.perf_counter()
                 await asyncio.gather(*tasks)
+                pipeline_duration = time.perf_counter() - start_pipeline
+                _LOGGER.debug(
+                    "[%s] metatile split pipeline in %.6fs (%d tiles)",
+                    metatile.tilecoord,
+                    pipeline_duration,
+                    len(tasks),
+                )
 
                 async with self.error_lock:
                     self.error += run.error
@@ -2336,6 +2365,7 @@ class HashDropper:
     ) -> None:
         self.size = size
         self.sha1code = sha1code
+        self.sha1digest = bytes.fromhex(sha1code)
         self.store = store
         self.queue_store = queue_store
         self.count = count
@@ -2343,7 +2373,9 @@ class HashDropper:
     async def __call__(self, tile: Tile) -> Tile | None:
         """Drop the tile if the size and hash are the same as the specified ones."""
         assert tile.data
-        if len(tile.data) != self.size or sha1(tile.data).hexdigest() != self.sha1code:  # noqa: S324
+        if len(tile.data) != self.size:
+            return tile
+        if sha1(tile.data).digest() != self.sha1digest:  # noqa: S324
             return tile
         if self.store is not None:
             if tile.tilecoord.n != 1:
@@ -2371,6 +2403,7 @@ class _DatedAction:
     """Dated action."""
 
     mtime: float
+    checked_at: float
     action: Callable[[Tile], Awaitable[Tile | None]]
 
 
@@ -2387,6 +2420,7 @@ class MultiAction:
     ) -> None:
         self.get_action = get_action
         self.actions: dict[tuple[Path, str], _DatedAction] = {}
+        self._cache_ttl_seconds = 10.0
 
     async def _get_action(
         self,
@@ -2394,19 +2428,27 @@ class MultiAction:
         layer: str,
     ) -> Callable[[Tile], Awaitable[Tile | None]] | None:
         """Get the action based on the tile's layer name."""
-        if not await config_file.exists():
-            _LOGGER.warning("Config file %s does not exist", config_file)
-            return None
-        config_stat = await config_file.stat()
-        mtime = config_stat.st_mtime
+        now = time.monotonic()
         action = self.actions.get((config_file, layer))
-        if action is not None and action.mtime != mtime:
-            action = None
-        if action is None:
-            action_item = await self.get_action(config_file, layer)
-            if action_item is not None:
-                action = _DatedAction(mtime, action_item)
-                self.actions[(config_file, layer)] = action
+        if action is None or now - action.checked_at >= self._cache_ttl_seconds:
+            if not await config_file.exists():
+                _LOGGER.warning("Config file %s does not exist", config_file)
+                self.actions.pop((config_file, layer), None)
+                return None
+
+            config_stat = await config_file.stat()
+            mtime = config_stat.st_mtime
+
+            if action is None or action.mtime != mtime:
+                action_item = await self.get_action(config_file, layer)
+                if action_item is not None:
+                    action = _DatedAction(mtime, now, action_item)
+                    self.actions[(config_file, layer)] = action
+                else:
+                    self.actions.pop((config_file, layer), None)
+                    return None
+            else:
+                action.checked_at = now
         return action.action if action is not None else None
 
     async def __call__(self, tile: Tile) -> Tile | None:

--- a/tilecloud_chain/__init__.py
+++ b/tilecloud_chain/__init__.py
@@ -2449,7 +2449,7 @@ class MultiAction:
                     return None
             else:
                 action.checked_at = now
-        return action.action if action is not None else None
+        return action.action
 
     async def __call__(self, tile: Tile) -> Tile | None:
         """Run the action."""

--- a/tilecloud_chain/__init__.py
+++ b/tilecloud_chain/__init__.py
@@ -1479,12 +1479,12 @@ class TileGeneration:
             tiles_count,
         )
 
-    async def _fetch_hash_tile(self, substream: AsyncIterator[Tile]) -> Tile:
+    async def _fetch_hash_tile(self, substream: AsyncIterator[Tile | None]) -> Tile:
         tile = await anext(substream)
         assert tile is not None
         return tile
 
-    async def _process_tiles_metatile(self, substream: AsyncIterator[Tile], run: Run) -> int:
+    async def _process_tiles_metatile(self, substream: AsyncIterator[Tile | None], run: Run) -> int:
         tasks = []
         async for tile in substream:
             assert tile is not None

--- a/tilecloud_chain/__init__.py
+++ b/tilecloud_chain/__init__.py
@@ -1449,50 +1449,55 @@ class TileGeneration:
 
         async def meta_get(metatile: Tile) -> Tile:
             assert store is not None
+            log_debug_timings = _LOGGER.isEnabledFor(logging.DEBUG)
 
             async def _async_metatile() -> AsyncIterator[Tile]:
                 yield metatile
 
-            start_split = time.perf_counter()
+            start_split = time.perf_counter() if log_debug_timings else 0.0
             substream = store.get(_async_metatile())
             if getattr(self.options, "role", "") == "hash":
                 tile = await anext(substream)
                 assert tile is not None
-                split_duration = time.perf_counter() - start_split
-                _LOGGER.debug(
-                    "[%s] metatile split fetch in %.6fs",
-                    metatile.tilecoord,
-                    split_duration,
-                )
-                start_pipeline = time.perf_counter()
+                if log_debug_timings:
+                    split_duration = time.perf_counter() - start_split
+                    _LOGGER.debug(
+                        "[%s] metatile split fetch in %.6fs",
+                        metatile.tilecoord,
+                        split_duration,
+                    )
+                start_pipeline = time.perf_counter() if log_debug_timings else 0.0
                 await run(tile)
-                pipeline_duration = time.perf_counter() - start_pipeline
-                _LOGGER.debug(
-                    "[%s] metatile split pipeline in %.6fs",
-                    metatile.tilecoord,
-                    pipeline_duration,
-                )
+                if log_debug_timings:
+                    pipeline_duration = time.perf_counter() - start_pipeline
+                    _LOGGER.debug(
+                        "[%s] metatile split pipeline in %.6fs",
+                        metatile.tilecoord,
+                        pipeline_duration,
+                    )
             else:
                 tasks = []
                 async for tile in substream:
                     assert tile is not None
                     tasks.append(run(tile))
-                split_duration = time.perf_counter() - start_split
-                _LOGGER.debug(
-                    "[%s] metatile split fetch in %.6fs (%d tiles)",
-                    metatile.tilecoord,
-                    split_duration,
-                    len(tasks),
-                )
-                start_pipeline = time.perf_counter()
+                if log_debug_timings:
+                    split_duration = time.perf_counter() - start_split
+                    _LOGGER.debug(
+                        "[%s] metatile split fetch in %.6fs (%d tiles)",
+                        metatile.tilecoord,
+                        split_duration,
+                        len(tasks),
+                    )
+                start_pipeline = time.perf_counter() if log_debug_timings else 0.0
                 await asyncio.gather(*tasks)
-                pipeline_duration = time.perf_counter() - start_pipeline
-                _LOGGER.debug(
-                    "[%s] metatile split pipeline in %.6fs (%d tiles)",
-                    metatile.tilecoord,
-                    pipeline_duration,
-                    len(tasks),
-                )
+                if log_debug_timings:
+                    pipeline_duration = time.perf_counter() - start_pipeline
+                    _LOGGER.debug(
+                        "[%s] metatile split pipeline in %.6fs (%d tiles)",
+                        metatile.tilecoord,
+                        pipeline_duration,
+                        len(tasks),
+                    )
 
                 async with self.error_lock:
                     self.error += run.error

--- a/tilecloud_chain/__init__.py
+++ b/tilecloud_chain/__init__.py
@@ -2365,6 +2365,11 @@ class HashDropper:
     ) -> None:
         self.size = size
         self.sha1code = sha1code
+        if len(sha1code) != 40 or re.fullmatch(r"[0-9a-fA-F]{40}", sha1code) is None:
+            raise ValueError(
+                "Invalid configuration for HashDropper.sha1code: "
+                f"expected a 40-character hexadecimal SHA-1 digest, got {sha1code!r}",
+            )
         self.sha1digest = bytes.fromhex(sha1code)
         self.store = store
         self.queue_store = queue_store

--- a/tilecloud_chain/__init__.py
+++ b/tilecloud_chain/__init__.py
@@ -603,6 +603,16 @@ class MissingErrorFileError(Exception):
     """Missing error file exception."""
 
 
+class InvalidHashDropperConfigurationError(ValueError):
+    """Raised when HashDropper configuration is invalid."""
+
+    def __init__(self, sha1code: str) -> None:
+        super().__init__(
+            "Invalid configuration for HashDropper.sha1code: "
+            f"expected a 40-character hexadecimal SHA-1 digest, got {sha1code!r}",
+        )
+
+
 class LoggingInformation(TypedDict):
     """Logging information."""
 
@@ -1416,95 +1426,116 @@ class TileGeneration:
         """Add a metatile splitter to the chain."""
         assert self.functions != self.functions_tiles, "add_metatile_splitter should not be called twice"
         if store is None:
-            gene = self
-
-            async def get_splitter(
-                config_file: Path,
-                layer_name: str,
-                grid_name: str | None,
-            ) -> AsyncTileStore | None:
-                config = await gene.get_config(config_file)
-                if layer_name not in config.config.get("layers", {}):
-                    _LOGGER.warning("Layer %s not found in config %s", layer_name, config_file)
-                    return None
-                layer = config.config["layers"][layer_name]
-                if layer.get("meta"):
-                    return TileStoreWrapper(
-                        MetaTileSplitterTileStore(
-                            layer["mime_type"],
-                            get_grid_config(config, layer_name, grid_name).get(
-                                "tile_size",
-                                configuration.TILE_SIZE_DEFAULT,
-                            ),
-                            layer.get("meta_buffer", configuration.LAYER_META_BUFFER_DEFAULT),
-                            save_options=layer.get("meta_save_options"),  # type: ignore[arg-type]
-                        ),
-                    )
-                return NoneTileStore()
-
-            store = TimedTileStoreWrapper(MultiTileStore(get_splitter), store_name="splitter")
+            store = TimedTileStoreWrapper(MultiTileStore(self._get_splitter), store_name="splitter")
 
         run = Run(self, self.functions_tiles, out=self.out)
         await run.init()
+        self.imap(self._build_meta_getter(store, run))
+        self.functions = self.functions_tiles
 
+    async def _get_splitter(
+        self,
+        config_file: Path,
+        layer_name: str,
+        grid_name: str | None,
+    ) -> AsyncTileStore | None:
+        config = await self.get_config(config_file)
+        if layer_name not in config.config.get("layers", {}):
+            _LOGGER.warning("Layer %s not found in config %s", layer_name, config_file)
+            return None
+        layer = config.config["layers"][layer_name]
+        if layer.get("meta"):
+            return TileStoreWrapper(
+                MetaTileSplitterTileStore(
+                    layer["mime_type"],
+                    get_grid_config(config, layer_name, grid_name).get(
+                        "tile_size",
+                        configuration.TILE_SIZE_DEFAULT,
+                    ),
+                    layer.get("meta_buffer", configuration.LAYER_META_BUFFER_DEFAULT),
+                    save_options=layer.get("meta_save_options"),  # type: ignore[arg-type]
+                ),
+            )
+        return NoneTileStore()
+
+    @staticmethod
+    def _log_metatile_timing(
+        enabled: bool,
+        metatile: Tile,
+        phase: str,
+        duration: float,
+        tiles_count: int | None = None,
+    ) -> None:
+        if not enabled:
+            return
+        if tiles_count is None:
+            _LOGGER.debug("[%s] metatile split %s in %.6fs", metatile.tilecoord, phase, duration)
+            return
+        _LOGGER.debug(
+            "[%s] metatile split %s in %.6fs (%d tiles)",
+            metatile.tilecoord,
+            phase,
+            duration,
+            tiles_count,
+        )
+
+    async def _fetch_hash_tile(self, substream: AsyncIterator[Tile]) -> Tile:
+        tile = await anext(substream)
+        assert tile is not None
+        return tile
+
+    async def _process_tiles_metatile(self, substream: AsyncIterator[Tile], run: Run) -> int:
+        tasks = []
+        async for tile in substream:
+            assert tile is not None
+            tasks.append(run(tile))
+        await asyncio.gather(*tasks)
+
+        async with self.error_lock:
+            self.error += run.error
+        return len(tasks)
+
+    async def _process_metatile(self, metatile: Tile, store: AsyncTileStore, run: Run) -> None:
+        log_debug_timings = _LOGGER.isEnabledFor(logging.DEBUG)
+
+        async def _async_metatile() -> AsyncIterator[Tile]:
+            yield metatile
+
+        start_split = time.perf_counter() if log_debug_timings else 0.0
+        substream = store.get(_async_metatile())
+        role = getattr(self.options, "role", "")
+        if role == "hash":
+            tile = await self._fetch_hash_tile(substream)
+            split_duration = time.perf_counter() - start_split if log_debug_timings else 0.0
+            self._log_metatile_timing(log_debug_timings, metatile, "fetch", split_duration)
+
+            start_pipeline = time.perf_counter() if log_debug_timings else 0.0
+            await run(tile)
+            pipeline_duration = time.perf_counter() - start_pipeline if log_debug_timings else 0.0
+            self._log_metatile_timing(log_debug_timings, metatile, "pipeline", pipeline_duration)
+            return
+
+        split_count = await self._process_tiles_metatile(substream, run)
+        split_duration = time.perf_counter() - start_split if log_debug_timings else 0.0
+        self._log_metatile_timing(log_debug_timings, metatile, "fetch", split_duration, split_count)
+
+        start_pipeline = time.perf_counter() if log_debug_timings else 0.0
+        pipeline_duration = time.perf_counter() - start_pipeline if log_debug_timings else 0.0
+        self._log_metatile_timing(
+            log_debug_timings,
+            metatile,
+            "pipeline",
+            pipeline_duration,
+            split_count,
+        )
+
+    def _build_meta_getter(self, store: AsyncTileStore, run: Run) -> Callable[[Tile], Awaitable[Tile]]:
         async def meta_get(metatile: Tile) -> Tile:
-            assert store is not None
-            log_debug_timings = _LOGGER.isEnabledFor(logging.DEBUG)
-
-            async def _async_metatile() -> AsyncIterator[Tile]:
-                yield metatile
-
-            start_split = time.perf_counter() if log_debug_timings else 0.0
-            substream = store.get(_async_metatile())
-            if getattr(self.options, "role", "") == "hash":
-                tile = await anext(substream)
-                assert tile is not None
-                if log_debug_timings:
-                    split_duration = time.perf_counter() - start_split
-                    _LOGGER.debug(
-                        "[%s] metatile split fetch in %.6fs",
-                        metatile.tilecoord,
-                        split_duration,
-                    )
-                start_pipeline = time.perf_counter() if log_debug_timings else 0.0
-                await run(tile)
-                if log_debug_timings:
-                    pipeline_duration = time.perf_counter() - start_pipeline
-                    _LOGGER.debug(
-                        "[%s] metatile split pipeline in %.6fs",
-                        metatile.tilecoord,
-                        pipeline_duration,
-                    )
-            else:
-                tasks = []
-                async for tile in substream:
-                    assert tile is not None
-                    tasks.append(run(tile))
-                if log_debug_timings:
-                    split_duration = time.perf_counter() - start_split
-                    _LOGGER.debug(
-                        "[%s] metatile split fetch in %.6fs (%d tiles)",
-                        metatile.tilecoord,
-                        split_duration,
-                        len(tasks),
-                    )
-                start_pipeline = time.perf_counter() if log_debug_timings else 0.0
-                await asyncio.gather(*tasks)
-                if log_debug_timings:
-                    pipeline_duration = time.perf_counter() - start_pipeline
-                    _LOGGER.debug(
-                        "[%s] metatile split pipeline in %.6fs (%d tiles)",
-                        metatile.tilecoord,
-                        pipeline_duration,
-                        len(tasks),
-                    )
-
-                async with self.error_lock:
-                    self.error += run.error
+            await self._process_metatile(metatile, store, run)
             return metatile
 
-        self.imap(meta_get)
-        self.functions = self.functions_tiles
+        return meta_get
+
 
     async def create_log_tiles_error(self, layer: str) -> anyio.AsyncFile[str] | None:
         """Create the error file for the given layer."""
@@ -2371,10 +2402,7 @@ class HashDropper:
         self.size = size
         self.sha1code = sha1code
         if len(sha1code) != 40 or re.fullmatch(r"[0-9a-fA-F]{40}", sha1code) is None:
-            raise ValueError(
-                "Invalid configuration for HashDropper.sha1code: "
-                f"expected a 40-character hexadecimal SHA-1 digest, got {sha1code!r}",
-            )
+            raise InvalidHashDropperConfigurationError(sha1code)
         self.sha1digest = bytes.fromhex(sha1code)
         self.store = store
         self.queue_store = queue_store

--- a/tilecloud_chain/__init__.py
+++ b/tilecloud_chain/__init__.py
@@ -1536,7 +1536,6 @@ class TileGeneration:
 
         return meta_get
 
-
     async def create_log_tiles_error(self, layer: str) -> anyio.AsyncFile[str] | None:
         """Create the error file for the given layer."""
         main_config = await self.get_main_config()


### PR DESCRIPTION
## What
- add a 10s TTL cache in MultiAction to avoid checking config file metadata on every tile
- optimize HashDropper by keeping the size-first fast path and comparing SHA1 binary digests
- add debug timings in meta_get to split metatile fetch/split time from per-tile pipeline time

## Why
During performance investigation, MultiAction and HashDropper showed significant cumulative overhead. These changes reduce repeated filesystem checks and hashing overhead, and improve observability for metatile split vs pipeline costs.