### PR TITLE
Include px_buffer in WMTS TileMatrixSetLimits

### DIFF
--- a/tilecloud_chain/__init__.py
+++ b/tilecloud_chain/__init__.py
@@ -765,17 +765,19 @@ def get_tile_matrix_limits(
     if min_x >= max_x or min_y >= max_y:
         return []
 
+    px_buffer = float(layer.get("px_buffer", configuration.LAYER_PIXEL_BUFFER_DEFAULT))
     tile_size = float(grid.get("tile_size", configuration.TILE_SIZE_DEFAULT))
     limits: list[dict[str, int | str]] = []
     for zoom, resolution in enumerate(grid["resolutions"]):
         tile_span = float(resolution) * tile_size
+        m_buffer = px_buffer * float(resolution)
         matrix_width = math.ceil((grid_bbox[2] - grid_bbox[0]) / tile_span)
         matrix_height = math.ceil((grid_bbox[3] - grid_bbox[1]) / tile_span)
 
-        min_tile_col = math.floor((min_x - grid_bbox[0]) / tile_span)
-        max_tile_col = math.ceil((max_x - grid_bbox[0]) / tile_span) - 1
-        min_tile_row = math.floor((grid_bbox[3] - max_y) / tile_span)
-        max_tile_row = math.ceil((grid_bbox[3] - min_y) / tile_span) - 1
+        min_tile_col = math.floor((min_x - m_buffer - grid_bbox[0]) / tile_span)
+        max_tile_col = math.ceil((max_x + m_buffer - grid_bbox[0]) / tile_span) - 1
+        min_tile_row = math.floor((grid_bbox[3] - (max_y + m_buffer)) / tile_span)
+        max_tile_row = math.ceil((grid_bbox[3] - (min_y - m_buffer)) / tile_span) - 1
 
         limits.append(
             {

--- a/tilecloud_chain/tests/test_generate.py
+++ b/tilecloud_chain/tests/test_generate.py
@@ -576,6 +576,43 @@ def test_get_tile_matrix_limits_with_reversed_bbox() -> None:
     ]
 
 
+def test_get_tile_matrix_limits_with_px_buffer() -> None:
+    config = DatedConfig(
+        cast(
+            "tcc_configuration.Configuration",
+            {
+                "layers": {
+                    "layer": {
+                        "bbox": [560000.0, 180000.0, 550000.0, 170000.0],
+                        "px_buffer": 100,
+                    },
+                },
+                "grids": {
+                    "grid": {
+                        "bbox": [420000.0, 30000.0, 900000.0, 350000.0],
+                        "resolutions": [100.0],
+                        "tile_size": 256,
+                    },
+                },
+            },
+        ),
+        0,
+        AnyioPath("config.yaml"),
+    )
+
+    limits = get_tile_matrix_limits(config, "layer", "grid")
+
+    assert limits == [
+        {
+            "tile_matrix": "0",
+            "min_tile_row": 6,
+            "max_tile_row": 7,
+            "min_tile_col": 4,
+            "max_tile_col": 5,
+        },
+    ]
+
+
 def test_get_geoms_respects_geometry_srid(monkeypatch: pytest.MonkeyPatch) -> None:
     class FakeCursor:
         def __init__(self, rows: list[tuple[bytes, int]]) -> None:


### PR DESCRIPTION
What\n- include layer px_buffer in WMTS TileMatrixSetLimits computation\n- convert px_buffer to map units per zoom (resolution * px_buffer) before row/col conversion\n- clamp limits to matrix bounds as before\n- add a unit test covering limits computation with px_buffer\n\nMaster flow\n- no change in master queue behavior\n- metatiles are still sent to the queue through self._gene.put(self._queue_tilestore) in tilecloud_chain/generate.py\n\nNotes\n- keeps meta_buffer behavior unchanged (not included in this change)\n- local targeted pytest run could not complete in this environment due to missing dependency requests_oauthlib during test collection