### PR TITLE
Fix admin retry to requeue only errored meta tiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - Fix geometry/bbox reprojection edge cases by normalizing bbox axis order before TileMatrixSetLimits and geom filtering, and by honoring PostGIS geometry SRID when present before intersecting with grid extents.
 - Reproject `geoms.datasource` geometries from layer CRS to grid CRS like PostGIS geoms, to avoid empty intersections when layer and grid use different SRS.
 - Show a clear admin error message when a generation command fails before producing output (for example, an unknown grid), and clarify PostgreSQL job ETA text with explicit units like `2 days 2 hours`.
+- Fix PostgreSQL admin retry action so it requeues only errored meta tiles instead of restarting full queue seeding for the whole job.
 
 Environment variable migration (legacy -> new)
 

--- a/tilecloud_chain/USAGE.rst
+++ b/tilecloud_chain/USAGE.rst
@@ -451,6 +451,9 @@ See the [configuration reference](https://github.com/camptocamp/tilecloud-chain/
 With that the admin page is enhance with a job concept with enhanced status and they can be
 canceled, and restarted.
 
+When retrying a job in error from the admin page, only the meta tiles currently in error are
+requeued. Successfully generated meta tiles are kept as-is and are not regenerated.
+
 Note that you should have an external process to clean the old jobs in the database.
 
 Amazon services

--- a/tilecloud_chain/store/postgresql.py
+++ b/tilecloud_chain/store/postgresql.py
@@ -457,7 +457,7 @@ class PostgresqlTileStore(AsyncTileStore):
                 update(Job)
                 .where(Job.id == job_id)
                 .values(
-                    status=_STATUS_CREATED,
+                    status=_STATUS_STARTED,
                     tiles_started_at=None,
                     meta_tiles_total=count_result,
                 ),

--- a/tilecloud_chain/tests/test_postgresql.py
+++ b/tilecloud_chain/tests/test_postgresql.py
@@ -108,7 +108,7 @@ async def test_retry(queue: tuple[int, int, int], SessionMaker: sessionmaker, ti
 
     with SessionMaker() as session:
         job = session.query(Job).filter(Job.id == job_id).one()
-        assert job.status == _STATUS_CREATED
+        assert job.status == _STATUS_STARTED
         assert job.tiles_started_at is None
         assert job.meta_tiles_total == 1
         metatiles = session.query(Queue).filter(Queue.job_id == job_id).all()


### PR DESCRIPTION
This fixes the admin PostgreSQL retry behavior.

- keep retried jobs in started state instead of resetting them to created
- requeue only queue entries in error
- keep ETA/status fields coherent by resetting tiles_started_at and recomputing meta_tiles_total
- update PostgreSQL retry test expectation
- document the behavior in the user guide and changelog