### PR TITLE
Fix WMTS FeatureInfo in admin test page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - In `/tiles/admin/test` add layer dimension selectors.
 - Batch PostgreSQL queue inserts (default 10,000 rows) for large metatile pyramids and add `TILECLOUD_CHAIN__POSTGRESQL__QUEUE_INSERT_BATCH_SIZE` to configure batch size.
 - Use WMTS GetFeatureInfo in the `/admin/test` OpenLayers page by querying the active layer on map click and showing the response in a feature info panel.
+- Fix `/admin/test` WMTS FeatureInfo requests by building KVP `GetFeatureInfo` URLs directly from WMTS source metadata instead of relying on a non-existent OpenLayers WMTS `getFeatureInfoUrl` method.
 - Update example tilegeneration configs to enable tile optimization (`post_process` with `optipng`/`jpegoptim` and Pillow `meta_save_options`).
 - Document how to combine `post_process` and `meta_save_options` to optimize PNG/JPEG tiles.
 - Add `TileMatrixSetLimits` entries in WMTS capabilities when a layer defines a `bbox`, so clients can restrict tile requests to the advertised extent.

--- a/tilecloud_chain/templates/openlayers.html
+++ b/tilecloud_chain/templates/openlayers.html
@@ -284,6 +284,117 @@
         return [wmtsLayer.InfoFormat];
       };
 
+      const toArray = function (value) {
+        if (!value) {
+          return [];
+        }
+        return Array.isArray(value) ? value : [value];
+      };
+
+      const hasAllowedValue = function (constraint, expectedValue) {
+        const allowedValues = toArray(constraint?.AllowedValues?.Value);
+        return allowedValues.some(function (value) {
+          return String(value).toUpperCase() === expectedValue;
+        });
+      };
+
+      const getKvpEndpoint = function (result) {
+        const operations = toArray(result?.OperationsMetadata?.Operation);
+        const getTileOperation = operations.find(function (operation) {
+          return operation?.name === 'GetTile';
+        });
+        const getMethods = toArray(getTileOperation?.DCP?.HTTP?.Get);
+
+        const method = getMethods.find(function (candidate) {
+          const constraints = toArray(candidate?.Constraint);
+          if (constraints.length === 0) {
+            return false;
+          }
+          const getEncoding = constraints.find(function (constraint) {
+            return constraint?.name === 'GetEncoding';
+          });
+          return hasAllowedValue(getEncoding, 'KVP');
+        });
+
+        return method?.href || method?.Href || null;
+      };
+
+      const getTileSize = function (tileGrid, tileCoordZ) {
+        const tileSize = tileGrid.getTileSize(tileCoordZ);
+        if (Array.isArray(tileSize)) {
+          return tileSize;
+        }
+        return [tileSize, tileSize];
+      };
+
+      const buildWmtsFeatureInfoUrl = function (source, clickCoordinate, resolution, infoFormat, kvpEndpoint) {
+        if (!source || !kvpEndpoint || !resolution || resolution <= 0) {
+          return null;
+        }
+
+        const tileGrid = source.getTileGrid();
+        if (!tileGrid) {
+          return null;
+        }
+
+        const tileCoordZ = tileGrid.getZForResolution(resolution);
+        if (!Number.isFinite(tileCoordZ)) {
+          return null;
+        }
+        const tileCoord = tileGrid.getTileCoordForCoordAndZ(clickCoordinate, tileCoordZ);
+        if (!tileCoord) {
+          return null;
+        }
+
+        const tileExtent = tileGrid.getTileCoordExtent(tileCoord);
+        if (!tileExtent) {
+          return null;
+        }
+
+        const tileSize = getTileSize(tileGrid, tileCoordZ);
+        const matrixIds = tileGrid.getMatrixIds ? tileGrid.getMatrixIds() : null;
+        const tileMatrix = matrixIds ? matrixIds[tileCoordZ] : tileCoordZ;
+        if (tileMatrix === undefined || tileMatrix === null) {
+          return null;
+        }
+
+        const tileCol = tileCoord[1];
+        const tileRow = tileCoord[2];
+        const i = Math.min(
+          tileSize[0] - 1,
+          Math.max(0, Math.floor((clickCoordinate[0] - tileExtent[0]) / resolution))
+        );
+        const j = Math.min(
+          tileSize[1] - 1,
+          Math.max(0, Math.floor((tileExtent[3] - clickCoordinate[1]) / resolution))
+        );
+
+        const params = new URLSearchParams({
+          'SERVICE': 'WMTS',
+          'VERSION': source.getVersion(),
+          'REQUEST': 'GetFeatureInfo',
+          'LAYER': source.getLayer(),
+          'STYLE': source.getStyle(),
+          'TILEMATRIXSET': source.getMatrixSet(),
+          'TILEMATRIX': String(tileMatrix),
+          'TILEROW': String(tileRow),
+          'TILECOL': String(tileCol),
+          'I': String(i),
+          'J': String(j),
+          'INFO_FORMAT': infoFormat,
+          'FORMAT': source.getFormat(),
+        });
+
+        const dimensions = source.getDimensions() || {};
+        Object.entries(dimensions).forEach(function ([name, value]) {
+          if (value !== undefined && value !== null && value !== '') {
+            params.set(name, String(value));
+          }
+        });
+
+        return kvpEndpoint + (kvpEndpoint.includes('?') ? '&' : '?') + params.toString();
+      };
+
       const getLegendUrls = function (legendUrls) {
         if (!legendUrls) {
           return [];
@@ -417,6 +528,7 @@
           let layers = [];
           let tileGridOptions = {};
           let visible = true;
+          const kvpEndpoint = getKvpEndpoint(result);
           for (const wmtsLayer of result.Contents.Layer) {
             const gridDefinitions = getLayerGridDefinitions(result, wmtsLayer);
             if (gridDefinitions.length === 0) {
@@ -459,6 +571,7 @@
                 legendDefinitions: layerLegendDefinitions,
                 gridDefinitions: gridDefinitions,
                 selectedGridId: selectedGridDefinition.id,
+                kvpEndpoint: kvpEndpoint,
               })
             );
             visible = false;
@@ -1033,14 +1146,15 @@
             }
 
             const source = activeBaseLayer.getSource();
-            if (!source || typeof source.getFeatureInfoUrl !== 'function') {
-              featureInfo.setContent('The active layer does not support WMTS GetFeatureInfo.');
-              return;
-            }
+            const kvpEndpoint = activeBaseLayer.get('kvpEndpoint');
 
             const infoFormats = activeBaseLayer.get('infoFormats') || [];
             if (infoFormats.length === 0) {
               featureInfo.setContent('The active layer is not queryable.');
+              return;
+            }
+            if (!source || !kvpEndpoint) {
+              featureInfo.setContent('The active layer does not support WMTS GetFeatureInfo.');
               return;
             }
 
@@ -1053,9 +1167,13 @@
               return;
             }
 
-            const url = source.getFeatureInfoUrl(event.coordinate, resolution, projection, {
-              'INFO_FORMAT': infoFormat,
-            });
+            const url = buildWmtsFeatureInfoUrl(
+              source,
+              event.coordinate,
+              resolution,
+              infoFormat,
+              kvpEndpoint
+            );
             if (!url) {
               featureInfo.setContent('Cannot build the WMTS GetFeatureInfo URL for this layer.');
               return;

--- a/tilecloud_chain/templates/openlayers.html
+++ b/tilecloud_chain/templates/openlayers.html
@@ -298,6 +298,13 @@
         });
       };
 
+      const getLinkHref = function (link) {
+        if (!link) {
+          return null;
+        }
+        return link.href || link.Href || link['xlink:href'] || link.xlinkHref || null;
+      };
+
       const getKvpEndpoint = function (result) {
         const operations = toArray(result?.OperationsMetadata?.Operation);
         const getTileOperation = operations.find(function (operation) {
@@ -316,7 +323,7 @@
           return hasAllowedValue(getEncoding, 'KVP');
         });
 
-        return method?.href || method?.Href || null;
+        return getLinkHref(method);
       };
 
       const getTileSize = function (tileGrid, tileCoordZ) {
@@ -433,11 +440,7 @@
 
         return getLegendUrls(selectedStyle ? selectedStyle.LegendURL : null)
           .map(function (legendUrl) {
-            const href =
-              legendUrl.href ||
-              legendUrl.Href ||
-              legendUrl['xlink:href'] ||
-              null;
+            const href = getLinkHref(legendUrl);
             if (!href) {
               return null;
             }

--- a/tilecloud_chain/tests/test_ui.py
+++ b/tilecloud_chain/tests/test_ui.py
@@ -80,6 +80,8 @@ def test_openlayers_test_page_uses_wmts_getfeatureinfo_on_click():
     content = (Path(__file__).parent.parent / "templates" / "openlayers.html").read_text()
 
     assert "map.on('singleclick', function (event) {" in content
+    assert "const getLinkHref = function (link) {" in content
+    assert "return link.href || link.Href || link['xlink:href'] || link.xlinkHref || null;" in content
     assert "const buildWmtsFeatureInfoUrl = function (source, clickCoordinate, resolution, infoFormat, kvpEndpoint)" in content
     assert "'REQUEST': 'GetFeatureInfo'," in content
     assert "'INFO_FORMAT': infoFormat," in content

--- a/tilecloud_chain/tests/test_ui.py
+++ b/tilecloud_chain/tests/test_ui.py
@@ -80,7 +80,8 @@ def test_openlayers_test_page_uses_wmts_getfeatureinfo_on_click():
     content = (Path(__file__).parent.parent / "templates" / "openlayers.html").read_text()
 
     assert "map.on('singleclick', function (event) {" in content
-    assert "source.getFeatureInfoUrl(event.coordinate, resolution, projection, {" in content
+    assert "const buildWmtsFeatureInfoUrl = function (source, clickCoordinate, resolution, infoFormat, kvpEndpoint)" in content
+    assert "'REQUEST': 'GetFeatureInfo'," in content
     assert "'INFO_FORMAT': infoFormat," in content
     assert "fetch(url)" in content
     assert "Feature info" in content


### PR DESCRIPTION
## Overview
- build WMTS GetFeatureInfo KVP URLs manually in /tiles/admin/test
- stop relying on ol.source.WMTS getFeatureInfoUrl
- keep layer dimensions in GetFeatureInfo requests
- update UI test assertions for the new URL building path
- document the user visible fix in CHANGELOG.md

## Context
The test page showed The active layer does not support WMTS GetFeatureInfo even when the layer was queryable in capabilities, because OpenLayers WMTS sources do not expose getFeatureInfoUrl like WMS sources do.