### PR TITLE
Add WMTS FeatureInfo ResourceURL support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Batch PostgreSQL queue inserts (default 10,000 rows) for large metatile pyramids and add `TILECLOUD_CHAIN__POSTGRESQL__QUEUE_INSERT_BATCH_SIZE` to configure batch size.
 - Use WMTS GetFeatureInfo in the `/admin/test` OpenLayers page by querying the active layer on map click and showing the response in a feature info panel.
 - Fix `/admin/test` WMTS FeatureInfo requests by building KVP `GetFeatureInfo` URLs directly from WMTS source metadata instead of relying on a non-existent OpenLayers WMTS `getFeatureInfoUrl` method.
+- Advertise WMTS FeatureInfo REST endpoints in capabilities with `ResourceURL` (`resourceType="FeatureInfo"`) and update the `/admin/test` page to read info formats from those entries (with `InfoFormat` fallback) for OpenLayers compatibility.
 - Update example tilegeneration configs to enable tile optimization (`post_process` with `optipng`/`jpegoptim` and Pillow `meta_save_options`).
 - Document how to combine `post_process` and `meta_save_options` to optimize PNG/JPEG tiles.
 - Add `TileMatrixSetLimits` entries in WMTS capabilities when a layer defines a `bbox`, so clients can restrict tile requests to the advertised extent.

--- a/tilecloud_chain/templates/openlayers.html
+++ b/tilecloud_chain/templates/openlayers.html
@@ -275,6 +275,24 @@
       };
 
       const getLayerInfoFormats = function (wmtsLayer) {
+        const resourceUrls = Array.isArray(wmtsLayer.ResourceURL)
+          ? wmtsLayer.ResourceURL
+          : (wmtsLayer.ResourceURL ? [wmtsLayer.ResourceURL] : []);
+        const formatsFromResourceUrls = resourceUrls
+          .filter(function (resourceUrl) {
+            return (
+              resourceUrl &&
+              String(resourceUrl.resourceType || '').toLowerCase() === 'featureinfo' &&
+              resourceUrl.format
+            );
+          })
+          .map(function (resourceUrl) {
+            return resourceUrl.format;
+          });
+        if (formatsFromResourceUrls.length > 0) {
+          return formatsFromResourceUrls;
+        }
+
         if (!wmtsLayer.InfoFormat) {
           return [];
         }

--- a/tilecloud_chain/templates/wmts_get_capabilities.jinja
+++ b/tilecloud_chain/templates/wmts_get_capabilities.jinja
@@ -169,8 +169,18 @@
                             %}/{{ ('{' + dimension['name'] + '}') }}{%
                         endfor
                    %}/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.{{ layer['extension'] }}" />{%
-       endfor %}{%
-         for grid_name in get_grid_names(config, layer_name) %}
+        if 'query_layers' in layer %}{%
+        for info_format in layer.get('info_formats', ['application/vnd.ogc.gml']) %}
+      <ResourceURL format="{{ info_format }}" resourceType="FeatureInfo"
+                   template="{{ base_url }}{{ base_url_postfix }}1.0.0/{{ layer_name }}/{{ layer['wmts_style'] }}{%
+                        for dimension in layer['dimensions']
+                            %}/{{ ('{' + dimension['name'] + '}') }}{%
+                        endfor
+                   %}/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}/{I}/{J}" />{%
+        endfor %}{%
+        endif %}{%
+        endfor %}{%
+          for grid_name in get_grid_names(config, layer_name) %}
       <TileMatrixSetLink>
         <TileMatrixSet>{{ grid_name }}</TileMatrixSet>{% set tile_matrix_limits = get_tile_matrix_limits(config, layer_name, grid_name) %}{%
         if tile_matrix_limits %}

--- a/tilecloud_chain/tests/test_serve.py
+++ b/tilecloud_chain/tests/test_serve.py
@@ -80,6 +80,9 @@ _CAPABILITIES = (
       <ResourceURL format="image/png" resourceType="tile"
                    template="http://wmts1/tiles/1.0.0/point_hash/default/{DATE}/"""
     r"""{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.png" />
+      <ResourceURL format="application/vnd.ogc.gml" resourceType="FeatureInfo"
+                   template="http://wmts1/tiles/1.0.0/point_hash/default/{DATE}/"""
+    r"""{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}/{I}/{J}" />
       <TileMatrixSetLink>
         <TileMatrixSet>swissgrid_5</TileMatrixSet>
       </TileMatrixSetLink>

--- a/tilecloud_chain/tests/test_ui.py
+++ b/tilecloud_chain/tests/test_ui.py
@@ -82,6 +82,7 @@ def test_openlayers_test_page_uses_wmts_getfeatureinfo_on_click():
     assert "map.on('singleclick', function (event) {" in content
     assert "const getLinkHref = function (link) {" in content
     assert "return link.href || link.Href || link['xlink:href'] || link.xlinkHref || null;" in content
+    assert "String(resourceUrl.resourceType || '').toLowerCase() === 'featureinfo'" in content
     assert "const buildWmtsFeatureInfoUrl = function (source, clickCoordinate, resolution, infoFormat, kvpEndpoint)" in content
     assert "'REQUEST': 'GetFeatureInfo'," in content
     assert "'INFO_FORMAT': infoFormat," in content


### PR DESCRIPTION
## Overview
This PR improves WMTS FeatureInfo interoperability in the `/admin/test` page.

## Changes
- Advertise WMTS FeatureInfo REST endpoints in capabilities with `ResourceURL` entries.
- Keep `InfoFormat` in capabilities and add one FeatureInfo `ResourceURL` per `info_format`.
- Update `/admin/test` OpenLayers parsing to read formats from FeatureInfo `ResourceURL` entries first.
- Keep an `InfoFormat` fallback in UI parsing for compatibility.
- Update related tests and `CHANGELOG.md`.

## Context
In our flow, OpenLayers WMTS capabilities parsing does not reliably expose layer `InfoFormat`, so queryable layers could appear as non-queryable in the test page even when capabilities included `InfoFormat`.