### PR TITLE
Handle OpenLayers named OperationsMetadata entries

### DIFF
--- a/tilecloud_chain/templates/openlayers.html
+++ b/tilecloud_chain/templates/openlayers.html
@@ -324,10 +324,12 @@
       };
 
       const getKvpEndpoint = function (result) {
-        const operations = toArray(result?.OperationsMetadata?.Operation);
-        const getTileOperation = operations.find(function (operation) {
-          return operation?.name === 'GetTile';
-        });
+        const operationsMetadata = result?.OperationsMetadata || {};
+        const getTileOperation =
+          operationsMetadata.GetTile ||
+          toArray(operationsMetadata.Operation).find(function (operation) {
+            return operation?.name === 'GetTile';
+          });
         const getMethods = toArray(getTileOperation?.DCP?.HTTP?.Get);
 
         const method = getMethods.find(function (candidate) {

--- a/tilecloud_chain/tests/test_ui.py
+++ b/tilecloud_chain/tests/test_ui.py
@@ -82,6 +82,8 @@ def test_openlayers_test_page_uses_wmts_getfeatureinfo_on_click():
     assert "map.on('singleclick', function (event) {" in content
     assert "const getLinkHref = function (link) {" in content
     assert "return link.href || link.Href || link['xlink:href'] || link.xlinkHref || null;" in content
+    assert "const operationsMetadata = result?.OperationsMetadata || {};" in content
+    assert "operationsMetadata.GetTile ||" in content
     assert "String(resourceUrl.resourceType || '').toLowerCase() === 'featureinfo'" in content
     assert "const buildWmtsFeatureInfoUrl = function (source, clickCoordinate, resolution, infoFormat, kvpEndpoint)" in content
     assert "'REQUEST': 'GetFeatureInfo'," in content


### PR DESCRIPTION
## Overview
Fix WMTS capabilities parsing in the `/admin/test` page when OpenLayers exposes `OperationsMetadata` operations as named keys.

## Changes
- Read `result.OperationsMetadata.GetTile` first when resolving the KVP endpoint.
- Keep fallback support for array-style `result.OperationsMetadata.Operation` parsing.
- Update the UI test expectations accordingly.

## Context
In OpenLayers parsing output, `result.OperationsMetadata.Operation` can be `undefined` while `result.OperationsMetadata.GetTile` is available. The previous code only checked the array-style path, which could make the KVP endpoint lookup fail.