### PR TITLE
Strip hop-by-hop headers in forwarded responses

### DIFF
--- a/.github/spell-ignore-words.txt
+++ b/.github/spell-ignore-words.txt
@@ -14,3 +14,4 @@ pyproj
 geoms
 bbox
 mask.geojson
+te

--- a/tilecloud_chain/server.py
+++ b/tilecloud_chain/server.py
@@ -752,7 +752,10 @@ class Server:
                     "transfer-encoding",
                     "upgrade",
                 }
-                connection_header = response_headers.get("Connection", "")
+                connection_header = next(
+                    (value for name, value in response_headers.items() if name.lower() == "connection"),
+                    "",
+                )
                 if connection_header:
                     hop_by_hop_headers.update(
                         header.strip().lower() for header in connection_header.split(",") if header.strip()

--- a/tilecloud_chain/server.py
+++ b/tilecloud_chain/server.py
@@ -737,9 +737,32 @@ class Server:
             headers["Cache-Control"] = "no-cache"
             headers["Pragma"] = "no-cache"
 
+        _LOGGER.debug("Forwarding request to WMS backend: %s", url)
+
         async with aiohttp.ClientSession() as session, session.get(url, headers=headers) as response:
             if response.status == 200:
                 response_headers = dict(response.headers)
+                hop_by_hop_headers = {
+                    "connection",
+                    "keep-alive",
+                    "proxy-authenticate",
+                    "proxy-authorization",
+                    "te",
+                    "trailer",
+                    "transfer-encoding",
+                    "upgrade",
+                }
+                connection_header = response_headers.get("Connection", "")
+                if connection_header:
+                    hop_by_hop_headers.update(
+                        header.strip().lower() for header in connection_header.split(",") if header.strip()
+                    )
+                hop_by_hop_headers.update({"content-length", "content-encoding"})
+                response_headers = {
+                    name: value
+                    for name, value in response_headers.items()
+                    if name.lower() not in hop_by_hop_headers
+                }
                 if no_cache:
                     response_headers["Cache-Control"] = "no-cache, no-store"
                     response_headers["Pragma"] = "no-cache"

--- a/tilecloud_chain/tests/test_serve.py
+++ b/tilecloud_chain/tests/test_serve.py
@@ -1285,6 +1285,40 @@ class TestServe(CompareCase):
         assert "x-drop-me" not in response.headers
 
     @pytest.mark.asyncio
+    async def test_forward_drops_connection_listed_headers_with_lowercase_connection_key(self) -> None:
+        server._PYRAMID_SERVER = None
+        server._TILEGENERATION = TileGeneration(
+            config_file=AnyioPath("tilegeneration/test-serve.yaml"),
+            configure_logging=False,
+        )
+
+        with Path("tilegeneration/test-serve.yaml").open() as f:
+            config = DatedConfig(
+                config=yaml.safe_load(f),
+                mtime=Path("tilegeneration/test-serve.yaml").stat().st_mtime,
+                file=AnyioPath("tilegeneration/test-serve.yaml"),
+            )
+
+        with patch("aiohttp.ClientSession.get") as mock_get:
+            mock_response = AsyncMock()
+            mock_response.status = 200
+            mock_response.headers = {
+                "Content-Type": "text/html",
+                "connection": "X-Case-Drop",
+                "X-Case-Drop": "yes",
+                "X-Remain": "ok",
+            }
+            mock_response.read.return_value = b"abc"
+            mock_get.return_value.__aenter__.return_value = mock_response
+
+            response = await server.server.forward(config, "http://example.test/wms")
+
+        assert response.status_code == 200
+        assert response.body == b"abc"
+        assert response.headers["x-remain"] == "ok"
+        assert "x-case-drop" not in response.headers
+
+    @pytest.mark.asyncio
     async def test_ondemend_wmtscapabilities(self) -> None:
         with LogCapture("tilecloud_chain", level=30) as log_capture:
             server._PYRAMID_SERVER = None

--- a/tilecloud_chain/tests/test_serve.py
+++ b/tilecloud_chain/tests/test_serve.py
@@ -1277,7 +1277,7 @@ class TestServe(CompareCase):
         assert response.body == b"abc"
         assert response.headers["content-type"] == "text/html"
         assert response.headers["x-remain"] == "ok"
-        assert "content-length" not in response.headers
+        assert response.headers["content-length"] == str(len(response.body))
         assert "content-encoding" not in response.headers
         assert "transfer-encoding" not in response.headers
         assert "connection" not in response.headers

--- a/tilecloud_chain/tests/test_serve.py
+++ b/tilecloud_chain/tests/test_serve.py
@@ -1241,6 +1241,50 @@ class TestServe(CompareCase):
             )
 
     @pytest.mark.asyncio
+    async def test_forward_drops_hop_by_hop_and_length_headers(self) -> None:
+        server._PYRAMID_SERVER = None
+        server._TILEGENERATION = TileGeneration(
+            config_file=AnyioPath("tilegeneration/test-serve.yaml"),
+            configure_logging=False,
+        )
+
+        with Path("tilegeneration/test-serve.yaml").open() as f:
+            config = DatedConfig(
+                config=yaml.safe_load(f),
+                mtime=Path("tilegeneration/test-serve.yaml").stat().st_mtime,
+                file=AnyioPath("tilegeneration/test-serve.yaml"),
+            )
+
+        with patch("aiohttp.ClientSession.get") as mock_get:
+            mock_response = AsyncMock()
+            mock_response.status = 200
+            mock_response.headers = {
+                "Content-Type": "text/html",
+                "Content-Length": "1",
+                "Content-Encoding": "gzip",
+                "Transfer-Encoding": "chunked",
+                "Connection": "keep-alive, X-Drop-Me",
+                "Keep-Alive": "timeout=5",
+                "X-Drop-Me": "yes",
+                "X-Remain": "ok",
+            }
+            mock_response.read.return_value = b"abc"
+            mock_get.return_value.__aenter__.return_value = mock_response
+
+            response = await server.server.forward(config, "http://example.test/wms")
+
+        assert response.status_code == 200
+        assert response.body == b"abc"
+        assert response.headers["content-type"] == "text/html"
+        assert response.headers["x-remain"] == "ok"
+        assert "content-length" not in response.headers
+        assert "content-encoding" not in response.headers
+        assert "transfer-encoding" not in response.headers
+        assert "connection" not in response.headers
+        assert "keep-alive" not in response.headers
+        assert "x-drop-me" not in response.headers
+
+    @pytest.mark.asyncio
     async def test_ondemend_wmtscapabilities(self) -> None:
         with LogCapture("tilecloud_chain", level=30) as log_capture:
             server._PYRAMID_SERVER = None


### PR DESCRIPTION
## Overview
Fix forwarded WMS responses that can crash Uvicorn with `Response content longer than Content-Length`.

## Changes
- Strip hop-by-hop headers from forwarded upstream responses.
- Remove `Content-Length`, `Content-Encoding`, and `Transfer-Encoding` before returning `Response`.
- Also drop headers named in the upstream `Connection` header.
- Add a debug log with the forwarded WMS request URL.
- Add a regression test for forwarded header filtering.

## Context
When forwarding upstream responses, preserving framing headers from the original connection can make Starlette/Uvicorn send a body that does not match the advertised content length, raising a runtime error.