### PR TITLE
Send WMS params and headers for GetFeatureInfo

### DIFF
--- a/tilecloud_chain/server.py
+++ b/tilecloud_chain/server.py
@@ -594,39 +594,41 @@ class Server:
                         detail="Not all required parameters are present, required parameters are I, J, and INFO_FORMAT",
                     )
                 if "query_layers" in layer:
+                    wms_params = {
+                        **cast("dict[str, str]", layer.get("params", {})),
+                        "SERVICE": "WMS",
+                        "VERSION": layer.get("version", "1.1.1"),
+                        "REQUEST": "GetFeatureInfo",
+                        "LAYERS": layer.get("layers", ""),
+                        "QUERY_LAYERS": layer.get("query_layers", layer.get("layers", "")),
+                        "STYLES": params["STYLE"],
+                        "FORMAT": params["FORMAT"],
+                        "INFO_FORMAT": params["INFO_FORMAT"],
+                        "WIDTH": grid.get(
+                            "tile_size",
+                            configuration.TILE_SIZE_DEFAULT,
+                        ),
+                        "HEIGHT": grid.get(
+                            "tile_size",
+                            configuration.TILE_SIZE_DEFAULT,
+                        ),
+                        "SRS": grid.get(
+                            "srs",
+                            configuration.SRS_DEFAULT,
+                        ),
+                        "BBOX": _TILEGENERATION.get_grid(config, params["TILEMATRIXSET"]).extent(
+                            tile.tilecoord,
+                        ),
+                        "X": params["I"],
+                        "Y": params["J"],
+                    }
+                    for dimension in layer.get("dimensions", []):
+                        wms_params[dimension["name"]] = metadata[f"dimension_{dimension['name']}"]
+
                     return await self.forward(
                         config,
-                        layer["url"]
-                        + "?"
-                        + urlencode(
-                            {
-                                "SERVICE": "WMS",
-                                "VERSION": layer.get("version", "1.1.1"),
-                                "REQUEST": "GetFeatureInfo",
-                                "LAYERS": layer.get("layers", ""),
-                                "QUERY_LAYERS": layer.get("query_layers", layer.get("layers", "")),
-                                "STYLES": params["STYLE"],
-                                "FORMAT": params["FORMAT"],
-                                "INFO_FORMAT": params["INFO_FORMAT"],
-                                "WIDTH": grid.get(
-                                    "tile_size",
-                                    configuration.TILE_SIZE_DEFAULT,
-                                ),
-                                "HEIGHT": grid.get(
-                                    "tile_size",
-                                    configuration.TILE_SIZE_DEFAULT,
-                                ),
-                                "SRS": grid.get(
-                                    "srs",
-                                    configuration.SRS_DEFAULT,
-                                ),
-                                "BBOX": _TILEGENERATION.get_grid(config, params["TILEMATRIXSET"]).extent(
-                                    tile.tilecoord,
-                                ),
-                                "X": params["I"],
-                                "Y": params["J"],
-                            },
-                        ),
+                        layer["url"] + "?" + urlencode(wms_params),
+                        headers=layer.get("headers", {}),
                         no_cache=True,
                     )
                 raise HTTPException(status_code=400, detail=f"Layer '{params['LAYER']}' not queryable")  # noqa: TRY301
@@ -733,6 +735,8 @@ class Server:
         """Forward the request on a fallback WMS server."""
         if headers is None:
             headers = {}
+        else:
+            headers = dict(headers)
         if no_cache:
             headers["Cache-Control"] = "no-cache"
             headers["Pragma"] = "no-cache"

--- a/tilecloud_chain/server.py
+++ b/tilecloud_chain/server.py
@@ -595,7 +595,7 @@ class Server:
                     )
                 if "query_layers" in layer:
                     wms_params = {
-                        **cast("dict[str, str]", layer.get("params", {})),
+                        **layer.get("params", {}),
                         "SERVICE": "WMS",
                         "VERSION": layer.get("version", "1.1.1"),
                         "REQUEST": "GetFeatureInfo",
@@ -733,10 +733,7 @@ class Server:
         **kwargs: Any,
     ) -> Response:
         """Forward the request on a fallback WMS server."""
-        if headers is None:
-            headers = {}
-        else:
-            headers = dict(headers)
+        headers = {} if headers is None else dict(headers)
         if no_cache:
             headers["Cache-Control"] = "no-cache"
             headers["Pragma"] = "no-cache"

--- a/tilecloud_chain/tests/test_serve.py
+++ b/tilecloud_chain/tests/test_serve.py
@@ -1081,6 +1081,48 @@ class TestServe(CompareCase):
 """,
         )
 
+        with patch("aiohttp.ClientSession.get") as mock_get:
+            mock_response = AsyncMock()
+            mock_response.status = 200
+            mock_response.read.return_value = b"ok"
+            mock_response.headers = {"Content-Type": "text/plain"}
+            mock_get.return_value.__aenter__.return_value = mock_response
+
+            with Path("tilegeneration/test-serve.yaml").open() as f:
+                patched_config = yaml.safe_load(f)
+            patched_config["layers"]["point_hash"]["params"] = {"CQL_FILTER": "foo=bar"}
+            patched_config["layers"]["point_hash"]["headers"] = {"Authorization": "Bearer token"}
+
+            config_with_params = DatedConfig(
+                config=patched_config,
+                mtime=Path("tilegeneration/test-serve.yaml").stat().st_mtime,
+                file=AnyioPath("tilegeneration/test-serve.yaml"),
+            )
+            params_with_dimensions = {
+                "SERVICE": "WMTS",
+                "VERSION": "1.0.0",
+                "REQUEST": "GetFeatureInfo",
+                "FORMAT": "image/png",
+                "INFO_FORMAT": "application/vnd.ogc.gml",
+                "LAYER": "point_hash",
+                "STYLE": "default",
+                "DATE": "2012",
+                "TILEMATRIXSET": "swissgrid_5",
+                "TILEMATRIX": "1",
+                "TILEROW": "11",
+                "TILECOL": "14",
+                "I": "114",
+                "J": "111",
+            }
+            response = await server.server.serve(params_with_dimensions, config_with_params, "localhost", None)
+
+        assert response.body == b"ok"
+        _, kwargs = mock_get.call_args
+        assert kwargs["headers"]["Authorization"] == "Bearer token"
+        called_url = mock_get.call_args.args[0]
+        assert "CQL_FILTER=foo%3Dbar" in called_url
+        assert "DATE=2012" in called_url
+
         server._PYRAMID_SERVER = None
         server._TILEGENERATION = TileGeneration(
             config_file=AnyioPath("tilegeneration/test-serve.yaml"),


### PR DESCRIPTION
## Overview
Ensure WMTS-to-WMS GetFeatureInfo proxy requests preserve layer-specific upstream configuration.

## Changes
- Merge `layer.params` into forwarded WMS GetFeatureInfo query parameters.
- Forward resolved WMTS dimensions (for example `DATE`, `floor`) to WMS GetFeatureInfo.
- Forward `layer.headers` (for example `Authorization`) to upstream requests.
- Copy forwarded request headers before mutating cache-control values.
- Add regression coverage for custom params, dimensions, and headers forwarding.

## Context
Some deployments rely on WMS-side filters, dimension handling, or auth headers defined in layer config. Without forwarding those values, GetFeatureInfo responses can be empty or incorrect even though WMTS requests look valid.