### PR TITLE
Fix ETA for direct PostgreSQL tile runs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@ the commit message should start with a capital letter.
 
 ## Pull requests
 
-The pull request description should not contain a `Testing` section.
+The pull request description should not contain a `Testing` or `Validation` section.
 
 ## Branch names
 

--- a/tilecloud_chain/store/postgresql.py
+++ b/tilecloud_chain/store/postgresql.py
@@ -421,10 +421,18 @@ class PostgresqlTileStore(AsyncTileStore):
         """Mark a pending job as started."""
         assert self.SessionMaker is not None
         async with self.SessionMaker() as session:
+            count_result = await session.scalar(
+                select(sqlalchemy.sql.functions.count(Queue.id)).where(Queue.job_id == job_id),
+            )
+            assert count_result is not None
             await session.execute(
                 update(Job)
                 .where(and_(Job.id == job_id, Job.status == _STATUS_PENDING))
-                .values(status=_STATUS_STARTED, started_at=datetime.datetime.now(tz=datetime.UTC)),
+                .values(
+                    status=_STATUS_STARTED,
+                    started_at=datetime.datetime.now(tz=datetime.UTC),
+                    meta_tiles_total=count_result,
+                ),
             )
             await session.commit()
 

--- a/tilecloud_chain/tests/test_postgresql.py
+++ b/tilecloud_chain/tests/test_postgresql.py
@@ -135,6 +135,27 @@ async def test_tiles_started_at_set_on_first_tile(
 
 
 @pytest.mark.asyncio
+async def test_start_job_sets_meta_tiles_total(
+    queue: tuple[int, int, int],
+    SessionMaker: sessionmaker,
+    tilestore: PostgresqlTileStore,
+) -> None:
+    job_id, _, _ = queue
+    with SessionMaker() as session:
+        job = session.query(Job).filter(Job.id == job_id).one()
+        job.status = _STATUS_PENDING
+        job.meta_tiles_total = 0
+        session.commit()
+
+    await tilestore.start_job(job_id)
+
+    with SessionMaker() as session:
+        job = session.query(Job).filter(Job.id == job_id).one()
+        assert job.status == _STATUS_STARTED
+        assert job.meta_tiles_total == 2
+
+
+@pytest.mark.asyncio
 async def test_get_status_with_eta(
     queue: tuple[int, int, int],
     SessionMaker: sessionmaker,


### PR DESCRIPTION
## Summary

- Store the generated metatile count when starting an auto-created PostgreSQL job from direct `generate-tiles` runs.
- Cover `start_job()` so it preserves the queue size in `meta_tiles_total` for ETA calculations.
