### PR TITLE
Fix transparent tile hash uniformity

### DIFF
--- a/tilecloud_chain/__init__.py
+++ b/tilecloud_chain/__init__.py
@@ -1642,7 +1642,10 @@ class HashLogger:
             assert tile.data
             _LOGGER.exception("%s: %s", str(ex), tile.data)
             raise
+        image = image.convert("RGBA")
         for px in image.getdata():  # type: ignore[attr-defined]
+            if px[3] == 0:
+                px = (0, 0, 0, 0)
             if ref is None:
                 ref = px
             elif px != ref:

--- a/tilecloud_chain/__init__.py
+++ b/tilecloud_chain/__init__.py
@@ -1642,8 +1642,8 @@ class HashLogger:
             assert tile.data
             _LOGGER.exception("%s: %s", str(ex), tile.data)
             raise
-        image = image.convert("RGBA")
-        for px in image.getdata():  # type: ignore[attr-defined]
+        rgba_image = image.convert("RGBA")
+        for px in rgba_image.getdata():  # type: ignore[attr-defined]
             if px[3] == 0:
                 px = (0, 0, 0, 0)
             if ref is None:

--- a/tilecloud_chain/tests/test_generate.py
+++ b/tilecloud_chain/tests/test_generate.py
@@ -81,7 +81,7 @@ class TestGenerate(CompareCase):
                 Tile(TileCoord(0, 0, 0), data=b"image", metadata={"layer": "test"})
             )
 
-        self.assertIn("empty_tile_detection", out.getvalue())
+        assert "empty_tile_detection" in out.getvalue()
 
     def test_get_bbox(self) -> None:
         for d in ("-d", ""):

--- a/tilecloud_chain/tests/test_generate.py
+++ b/tilecloud_chain/tests/test_generate.py
@@ -1,13 +1,16 @@
 import os
 import shutil
+from io import StringIO
 from itertools import product, repeat
+from unittest.mock import patch
 
 import pytest
 from PIL import Image
 from testfixtures import LogCapture
+from tilecloud import Tile, TileCoord
 from tilecloud.store.redis import RedisTileStore
 
-from tilecloud_chain import controller, generate
+from tilecloud_chain import HashLogger, controller, generate
 from tilecloud_chain.tests import CompareCase
 
 
@@ -62,6 +65,23 @@ class TestGenerate(CompareCase):
                         "Error: image is not uniform.",
                     ),
                 )
+
+    def test_hash_logger_ignores_hidden_rgb_on_transparent_pixels(self) -> None:
+        class ImageStub:
+            def convert(self, mode: str) -> "ImageStub":
+                assert mode == "RGBA"
+                return self
+
+            def getdata(self) -> list[tuple[int, int, int, int]]:
+                return [(0, 0, 0, 0), (255, 255, 255, 0)]
+
+        out = StringIO()
+        with patch("tilecloud_chain.Image.open", return_value=ImageStub()):
+            HashLogger("empty_tile_detection", out)(
+                Tile(TileCoord(0, 0, 0), data=b"image", metadata={"layer": "test"})
+            )
+
+        self.assertIn("empty_tile_detection", out.getvalue())
 
     def test_get_bbox(self) -> None:
         for d in ("-d", ""):


### PR DESCRIPTION
## Summary
- Normalize fully transparent pixels before checking hash tile uniformity
- Keep the hash based on the original encoded tile bytes
- Add a regression test for transparent pixels with different hidden RGB values

<!-- pull request links -->
See JIRA issue: [GSPUL-124](https://camptocamp.atlassian.net/browse/GSPUL-124).

[GSPUL-124]: https://camptocamp.atlassian.net/browse/GSPUL-124?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ