### PR TITLE
Add WMTS REST routes for layers without dimensions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,10 @@ The project must use async-friendly APIs for I/O to don't block the event loop.
 - `aiofiles` must not be used, use `anyio.Path` instead.
 - All disk or network operation must be done with async API; avoid blocking calls on the event loop.
 - Don't allow sequential `await` calls in loops; use e.g. `asyncio.gather` or `asyncio.TaskGroup`.
+- FastAPI calls `run_in_threadpool()` on synchronous (`def`) `Depends()` functions, spawning a thread
+  even for pure in-memory work. Always use `async def` for FastAPI dependency functions, even when
+  there is no `await` inside. Linter warnings about `async def` without `await` are false positives
+  in this context and should be ignored.
 
 ## Environment variables
 

--- a/tilecloud_chain/server.py
+++ b/tilecloud_chain/server.py
@@ -832,7 +832,7 @@ async def startup(_main_app: FastAPI) -> None:
     await init_tilegeneration(config_file)
 
 
-def get_host_name(request: Request) -> str:
+async def get_host_name(request: Request) -> str:
     """Get the host name from the request."""
     # Get the Host header
     host = request.headers.get("Host")

--- a/tilecloud_chain/server.py
+++ b/tilecloud_chain/server.py
@@ -879,6 +879,84 @@ async def get_host_config(
     return config
 
 
+async def _get_layer_obj(
+    layer: Annotated[str, fastapi.Path(..., description="Layer name")],
+    config: Annotated[tilecloud_chain.DatedConfig, fastapi.Depends(get_host_config)],
+) -> "tilecloud_chain.configuration.LayerWms":
+    if layer in server.get_layers(config):
+        return cast(
+            "tilecloud_chain.configuration.LayerWms",
+            config.config["layers"][layer],
+        )
+    raise HTTPException(status_code=400, detail=f"Wrong Layer '{layer}'")
+
+
+async def _get_tile_params(
+    version: Annotated[str, fastapi.Path(..., description="WMTS version")],
+    layer: Annotated[str, fastapi.Path(..., description="Layer name")],
+    style: Annotated[str, fastapi.Path(..., description="Style name")],
+    tilematrixset: Annotated[str, fastapi.Path(..., description="Tile matrix set")],
+    tilematrix: Annotated[str, fastapi.Path(..., description="Tile matrix")],
+    tilerow: Annotated[int, fastapi.Path(..., description="Tile row")],
+    tilecol: Annotated[int, fastapi.Path(..., description="Tile column")],
+    extension: Annotated[
+        Literal["jpg", "jpeg", "png", "webp", "json"],
+        fastapi.Path(..., description="File extension"),
+    ],
+) -> dict[str, str]:
+    params: dict[str, str] = {
+        "SERVICE": "WMTS",
+        "VERSION": version,
+        "REQUEST": "GetTile",
+        "LAYER": layer,
+        "STYLE": style,
+        "TILEMATRIXSET": tilematrixset,
+        "TILEMATRIX": tilematrix,
+        "TILEROW": tilerow,  # type: ignore[dict-item]
+        "TILECOL": tilecol,  # type: ignore[dict-item]
+    }
+    if extension == "webp":
+        params["FORMAT"] = "image/webp"
+    elif extension == "png":
+        params["FORMAT"] = "image/png"
+    elif extension in ("jpg", "jpeg"):
+        params["FORMAT"] = "image/jpeg"
+    elif extension == "json":
+        params["FORMAT"] = "application/json"
+    else:
+        raise HTTPException(status_code=400, detail=f"Wrong extension '{extension}'")
+    return params
+
+
+async def _get_feature_info_params(
+    version: Annotated[str, fastapi.Path(..., description="WMTS version")],
+    layer: Annotated[str, fastapi.Path(..., description="Layer name")],
+    style: Annotated[str, fastapi.Path(..., description="Style name")],
+    tilematrixset: Annotated[str, fastapi.Path(..., description="Tile matrix set")],
+    tilematrix: Annotated[str, fastapi.Path(..., description="Tile matrix")],
+    tilerow: Annotated[int, fastapi.Path(..., description="Tile row")],
+    tilecol: Annotated[int, fastapi.Path(..., description="Tile column")],
+    i: Annotated[int, fastapi.Path(..., description="Pixel I coordinate")],
+    j: Annotated[int, fastapi.Path(..., description="Pixel J coordinate")],
+    layer_obj: Annotated["tilecloud_chain.configuration.LayerWms", fastapi.Depends(_get_layer_obj)],
+) -> dict[str, str]:
+    return {
+        "SERVICE": "WMTS",
+        "VERSION": version,
+        "REQUEST": "GetFeatureInfo",
+        "LAYER": layer,
+        "STYLE": style,
+        "TILEMATRIXSET": tilematrixset,
+        "TILEMATRIX": tilematrix,
+        "TILEROW": tilerow,  # type: ignore[dict-item]
+        "TILECOL": tilecol,  # type: ignore[dict-item]
+        "I": i,  # type: ignore[dict-item]
+        "J": j,  # type: ignore[dict-item]
+        "INFO_FORMAT": layer_obj.get("info_formats", ["application/vnd.ogc.gml"])[0],
+        "FORMAT": layer_obj["mime_type"],
+    }
+
+
 @router.get(f"{route_prefix}{{version}}/WMTSCapabilities.xml", summary="Get the WMTS capabilities.")
 async def wmts_capabilities(
     request: Request,
@@ -898,26 +976,61 @@ async def wmts_capabilities(
     return await server.serve(params, config, host, request)
 
 
-@router.get(
-    f"{route_prefix}{{version}}/{{layer}}/{{style}}/{{dimensions_parameters:path}}/{{tilematrixset}}/{{tilematrix}}/{{tilerow}}/{{tilecol}}/{{i}}/{{j}}",
-    summary="Get the WMTS Feature Info.",
-)
+async def _serve_wmts_feature_info(
+    request: Request,
+    layer: str,
+    layer_obj: "tilecloud_chain.configuration.LayerWms",
+    params: dict[str, str],
+    config: tilecloud_chain.DatedConfig,
+    host: str,
+    dimensions_parameters: str | None = None,
+) -> Response:
+    dimensions: list[tilecloud_chain.configuration.LayerDimensionsItem] = layer_obj.get("dimensions", [])
+    if dimensions:
+        if dimensions_parameters is None:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Layer '{layer}' has dimensions; include them in the URL path.",
+            )
+        _add_dimensions_to_params(params, layer, dimensions, dimensions_parameters)
+    return await server.serve(params, config, host, request)
+
+
 @router.get(
     f"{route_prefix}{{version}}/{{layer}}/{{style}}/{{dimensions_parameters:path}}/{{tilematrixset}}/{{tilematrix}}/{{tilerow}}/{{tilecol}}/{{i}}/{{j}}.xml",
     summary="Get the WMTS Feature Info.",
 )
 async def wmts_feature_info(
-    version: Annotated[str, fastapi.Path(..., description="WMTS version")],
-    layer: Annotated[str, fastapi.Path(..., description="Layer name")],
-    style: Annotated[str, fastapi.Path(..., description="Style name")],
-    dimensions_parameters: Annotated[str, fastapi.Path(..., description="Dimensions parameters")],
-    tilematrixset: Annotated[str, fastapi.Path(..., description="Tile matrix set")],
-    tilematrix: Annotated[str, fastapi.Path(..., description="Tile matrix")],
-    tilerow: Annotated[int, fastapi.Path(..., description="Tile row")],
-    tilecol: Annotated[int, fastapi.Path(..., description="Tile column")],
-    i: Annotated[int, fastapi.Path(..., description="Pixel I coordinate")],
-    j: Annotated[int, fastapi.Path(..., description="Pixel J coordinate")],
     request: Request,
+    layer: Annotated[str, fastapi.Path(..., description="Layer name")],
+    layer_obj: Annotated["tilecloud_chain.configuration.LayerWms", fastapi.Depends(_get_layer_obj)],
+    params: Annotated[dict[str, str], fastapi.Depends(_get_feature_info_params)],
+    config: Annotated[tilecloud_chain.DatedConfig, fastapi.Depends(get_host_config)],
+    host: Annotated[str, fastapi.Depends(get_host_name)],
+    dimensions_parameters: Annotated[str, fastapi.Path(..., description="Dimensions parameters")],
+) -> Response:
+    """
+    Get the WMTS Feature Info.
+
+    This is a proxy to a WMS GetFeatureInfo.
+    """
+    return await _serve_wmts_feature_info(
+        request, layer, layer_obj, params, config, host, dimensions_parameters
+    )
+
+
+@router.get(
+    f"{route_prefix}{{version}}/{{layer}}/{{style}}/{{tilematrixset}}/{{tilematrix}}/{{tilerow}}/{{tilecol}}/{{i}}/{{j}}.xml",
+    summary="Get the WMTS Feature Info.",
+    responses={
+        400: {"description": "Layer not found or layer has dimensions that must be provided in the URL path."}
+    },
+)
+async def wmts_feature_info_no_dimensions(
+    request: Request,
+    layer: Annotated[str, fastapi.Path(..., description="Layer name")],
+    layer_obj: Annotated["tilecloud_chain.configuration.LayerWms", fastapi.Depends(_get_layer_obj)],
+    params: Annotated[dict[str, str], fastapi.Depends(_get_feature_info_params)],
     config: Annotated[tilecloud_chain.DatedConfig, fastapi.Depends(get_host_config)],
     host: Annotated[str, fastapi.Depends(get_host_name)],
 ) -> Response:
@@ -925,36 +1038,28 @@ async def wmts_feature_info(
     Get the WMTS Feature Info.
 
     This is a proxy to a WMS GetFeatureInfo.
+    For layers without dimensions, omit the dimensions segment in the URL.
     """
+    return await _serve_wmts_feature_info(request, layer, layer_obj, params, config, host)
 
-    if layer in server.get_layers(config):
-        layer_obj = cast(
-            "tilecloud_chain.configuration.LayerWms",
-            config.config["layers"][layer],
-        )
-    else:
-        raise HTTPException(status_code=400, detail=f"Wrong Layer '{layer}'")
 
-    params: dict[str, str] = {
-        "SERVICE": "WMTS",
-        "VERSION": version,
-        "REQUEST": "GetFeatureInfo",
-        "LAYER": layer,
-        "STYLE": style,
-        "TILEMATRIXSET": tilematrixset,
-        "TILEMATRIX": tilematrix,
-        "TILEROW": tilerow,  # type: ignore[dict-item]
-        "TILECOL": tilecol,  # type: ignore[dict-item]
-        "I": i,  # type: ignore[dict-item]
-        "J": j,  # type: ignore[dict-item]
-        "INFO_FORMAT": layer_obj.get("info_formats", ["application/vnd.ogc.gml"])[0],
-        "FORMAT": layer_obj["mime_type"],
-    }
-
+async def _serve_wmts_tile(
+    request: Request,
+    layer: str,
+    layer_obj: "tilecloud_chain.configuration.LayerWms",
+    params: dict[str, str],
+    config: tilecloud_chain.DatedConfig,
+    host: str,
+    dimensions_parameters: str | None = None,
+) -> Response:
     dimensions: list[tilecloud_chain.configuration.LayerDimensionsItem] = layer_obj.get("dimensions", [])
     if dimensions:
+        if dimensions_parameters is None:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Layer '{layer}' has dimensions; include them in the URL path.",
+            )
         _add_dimensions_to_params(params, layer, dimensions, dimensions_parameters)
-
     return await server.serve(params, config, host, request)
 
 
@@ -963,21 +1068,13 @@ async def wmts_feature_info(
     summary="Get the WMTS tile.",
 )
 async def wmts_tile(
-    version: Annotated[str, fastapi.Path(..., description="WMTS version")],
-    layer: Annotated[str, fastapi.Path(..., description="Layer name")],
-    style: Annotated[str, fastapi.Path(..., description="Style name")],
-    dimensions_parameters: Annotated[str, fastapi.Path(..., description="Dimensions parameters")],
-    tilematrixset: Annotated[str, fastapi.Path(..., description="Tile matrix set")],
-    tilematrix: Annotated[str, fastapi.Path(..., description="Tile matrix")],
-    tilerow: Annotated[int, fastapi.Path(..., description="Tile row")],
-    tilecol: Annotated[int, fastapi.Path(..., description="Tile column")],
-    extension: Annotated[
-        Literal["jpg", "jpeg", "png", "webp", "json"],
-        fastapi.Path(..., description="File extension"),
-    ],
     request: Request,
+    layer: Annotated[str, fastapi.Path(..., description="Layer name")],
+    layer_obj: Annotated["tilecloud_chain.configuration.LayerWms", fastapi.Depends(_get_layer_obj)],
+    params: Annotated[dict[str, str], fastapi.Depends(_get_tile_params)],
     config: Annotated[tilecloud_chain.DatedConfig, fastapi.Depends(get_host_config)],
     host: Annotated[str, fastapi.Depends(get_host_name)],
+    dimensions_parameters: Annotated[str, fastapi.Path(..., description="Dimensions parameters")],
 ) -> Response:
     """
     Get the WMTS tile.
@@ -988,43 +1085,77 @@ async def wmts_tile(
     - From dynamic cache (Redis).
     - Generate from WMS if it does not exist in the cache.
     """
+    return await _serve_wmts_tile(request, layer, layer_obj, params, config, host, dimensions_parameters)
 
-    if layer in server.get_layers(config):
-        layer_obj = cast(
-            "tilecloud_chain.configuration.LayerWms",
-            config.config["layers"][layer],
-        )
-    else:
-        raise HTTPException(status_code=400, detail=f"Wrong Layer '{layer}'")
 
-    params: dict[str, str] = {
-        "SERVICE": "WMTS",
-        "VERSION": version,
-        "REQUEST": "GetTile",
-        "LAYER": layer,
-        "STYLE": style,
-        "TILEMATRIXSET": tilematrixset,
-        "TILEMATRIX": tilematrix,
-        "TILEROW": tilerow,  # type: ignore[dict-item]
-        "TILECOL": tilecol,  # type: ignore[dict-item]
-    }
+@router.get(
+    f"{route_prefix}{{version}}/{{layer}}/{{style}}/{{tilematrixset}}/{{tilematrix}}/{{tilerow}}/{{tilecol}}.{{extension}}",
+    summary="Get the WMTS tile.",
+    responses={
+        400: {"description": "Layer not found or layer has dimensions that must be provided in the URL path."}
+    },
+)
+async def wmts_tile_no_dimensions(
+    request: Request,
+    layer: Annotated[str, fastapi.Path(..., description="Layer name")],
+    layer_obj: Annotated["tilecloud_chain.configuration.LayerWms", fastapi.Depends(_get_layer_obj)],
+    params: Annotated[dict[str, str], fastapi.Depends(_get_tile_params)],
+    config: Annotated[tilecloud_chain.DatedConfig, fastapi.Depends(get_host_config)],
+    host: Annotated[str, fastapi.Depends(get_host_name)],
+) -> Response:
+    """
+    Get the WMTS tile.
 
-    dimensions: list[tilecloud_chain.configuration.LayerDimensionsItem] = layer_obj.get("dimensions", [])
-    if dimensions:
-        _add_dimensions_to_params(params, layer, dimensions, dimensions_parameters)
+    For layers without dimensions, omit the dimensions segment in the URL.
+    """
+    return await _serve_wmts_tile(request, layer, layer_obj, params, config, host)
 
-    if extension == "webp":
-        params["FORMAT"] = "image/webp"
-    elif extension == "png":
-        params["FORMAT"] = "image/png"
-    elif extension in ("jpg", "jpeg"):
-        params["FORMAT"] = "image/jpeg"
-    elif extension == "json":
-        params["FORMAT"] = "application/json"
-    else:
-        raise HTTPException(status_code=400, detail=f"Wrong extension '{extension}'")
 
-    return await server.serve(params, config, host, request)
+@router.get(
+    f"{route_prefix}{{version}}/{{layer}}/{{style}}/{{dimensions_parameters:path}}/{{tilematrixset}}/{{tilematrix}}/{{tilerow}}/{{tilecol}}/{{i}}/{{j}}",
+    summary="Get the WMTS Feature Info.",
+)
+async def wmts_feature_info_without_xml(
+    request: Request,
+    layer: Annotated[str, fastapi.Path(..., description="Layer name")],
+    layer_obj: Annotated["tilecloud_chain.configuration.LayerWms", fastapi.Depends(_get_layer_obj)],
+    params: Annotated[dict[str, str], fastapi.Depends(_get_feature_info_params)],
+    config: Annotated[tilecloud_chain.DatedConfig, fastapi.Depends(get_host_config)],
+    host: Annotated[str, fastapi.Depends(get_host_name)],
+    dimensions_parameters: Annotated[str, fastapi.Path(..., description="Dimensions parameters")],
+) -> Response:
+    """
+    Get the WMTS Feature Info.
+
+    This is a proxy to a WMS GetFeatureInfo.
+    """
+    return await _serve_wmts_feature_info(
+        request, layer, layer_obj, params, config, host, dimensions_parameters
+    )
+
+
+@router.get(
+    f"{route_prefix}{{version}}/{{layer}}/{{style}}/{{tilematrixset}}/{{tilematrix}}/{{tilerow}}/{{tilecol}}/{{i}}/{{j}}",
+    summary="Get the WMTS Feature Info.",
+    responses={
+        400: {"description": "Layer not found or layer has dimensions that must be provided in the URL path."}
+    },
+)
+async def wmts_feature_info_without_xml_no_dimensions(
+    request: Request,
+    layer: Annotated[str, fastapi.Path(..., description="Layer name")],
+    layer_obj: Annotated["tilecloud_chain.configuration.LayerWms", fastapi.Depends(_get_layer_obj)],
+    params: Annotated[dict[str, str], fastapi.Depends(_get_feature_info_params)],
+    config: Annotated[tilecloud_chain.DatedConfig, fastapi.Depends(get_host_config)],
+    host: Annotated[str, fastapi.Depends(get_host_name)],
+) -> Response:
+    """
+    Get the WMTS Feature Info.
+
+    This is a proxy to a WMS GetFeatureInfo.
+    For layers without dimensions, omit the dimensions segment in the URL.
+    """
+    return await _serve_wmts_feature_info(request, layer, layer_obj, params, config, host)
 
 
 @router.get("/", summary="KVP interface.")

--- a/tilecloud_chain/tests/test_serve.py
+++ b/tilecloud_chain/tests/test_serve.py
@@ -1216,7 +1216,7 @@ class TestServe(CompareCase):
             mock_response.headers = {"Content-Type": "application/xml"}
             mock_get.return_value.__aenter__.return_value = mock_response
 
-            # 1. GetFeatureInfo
+            # GetFeatureInfo
             response = client.get(
                 "/tiles/1.0.0/point_hash/default/2012/swissgrid_5/1/11/14/114/111.xml",
                 params={
@@ -1236,27 +1236,34 @@ class TestServe(CompareCase):
 """,
             )
 
-            # 2. GetTile (204 No Content)
+            # GetTile (204 No Content)
             # Row 12 -> TMS Row 12 (if height 25).
             # We inserted Row 13 (WMTS 11). So WMTS 12 (TMS 12) should be empty.
             response = client.get("/tiles/1.0.0/point_hash/default/2012/swissgrid_5/1/11/12.png")
             assert response.status_code == 204
 
-            # 3. GetTile (200 OK)
+            # GetTile (200 OK)
             # Row 11 -> TMS Row 13.
             response = client.get("/tiles/1.0.0/point_hash/default/2012/swissgrid_5/1/11/14.png")
             assert response.status_code == 200
             assert response.headers["Cache-Control"] == "max-age=28800"
             assert response.headers["Content-Type"] == "image/png"
 
-            # 4. GetTile with wrong dimensions (empty value)
+            # GetTile without dimensions on a layer that requires them
+            response = client.get("/tiles/1.0.0/point_hash/default/swissgrid_5/1/11/14.png")
+            assert response.status_code == 400
+            assert response.json()["detail"] == (
+                "Layer 'point_hash' has dimensions; include them in the URL path."
+            )
+
+            # GetTile with wrong dimensions (empty value)
             response = client.get("/tiles/1.0.0/point_hash/default//swissgrid_5/1/11/14.png")
             assert response.status_code == 400
             assert response.json()["detail"] == (
                 "Wrong dimensions for layer 'point_hash': empty value(s) for dimension(s): DATE"
             )
 
-            # 5. GetTile with wrong dimensions (extra value)
+            # GetTile with wrong dimensions (extra value)
             response = client.get("/tiles/1.0.0/point_hash/default/2012/extra/swissgrid_5/1/11/14.png")
             assert response.status_code == 400
             assert response.json()["detail"] == (
@@ -1264,7 +1271,7 @@ class TestServe(CompareCase):
                 "got 2 value(s) (2012, extra); unexpected value(s): extra"
             )
 
-            # 6. GetTile with wrong dimensions value
+            # GetTile with wrong dimensions value
             response = client.get("/tiles/1.0.0/point_hash/default/20231011/swissgrid_5/1/11/14.png")
             assert response.status_code == 400
             assert response.json()["detail"] == (
@@ -1272,7 +1279,7 @@ class TestServe(CompareCase):
                 "DATE='20231011' not in allowed values (2005, 2010, 2012)"
             )
 
-            # 7. GetCapabilities
+            # GetCapabilities
             response = client.get("/tiles/1.0.0/WMTSCapabilities.xml")
             assert response.status_code == 200
             assert response.headers["Content-Type"] == "application/xml"
@@ -1280,6 +1287,79 @@ class TestServe(CompareCase):
                 response.text,
                 _CAPABILITIES,
                 regex=True,
+            )
+
+    @pytest.mark.asyncio
+    async def test_rest_no_dimension_routes(self) -> None:
+        from fastapi import FastAPI
+        from fastapi.testclient import TestClient
+
+        from tilecloud_chain.server import router
+
+        server._PYRAMID_SERVER = None
+        server.server.store_cache = {}
+        server._TILEGENERATION = TileGeneration(
+            config_file=AnyioPath("tilegeneration/test-nodim.yaml"),
+            configure_logging=False,
+        )
+
+        app = FastAPI()
+        app.include_router(router)
+        client = TestClient(app)
+
+        async def get_one_side_effect(tile):
+            if tile.tilecoord.z == 1 and tile.tilecoord.x == 14 and tile.tilecoord.y == 11:
+                t = MagicMock()
+                t.data = b"dummy_png"
+                t.content_type = "image/png"
+                t.error = None
+                return t
+            return None
+
+        with (
+            patch("aiohttp.ClientSession.get") as mock_get,
+            patch("tilecloud_chain.IntersectGeometryFilter.filter_tilecoord", return_value=True),
+            patch.object(server._TILEGENERATION, "get_store", new_callable=AsyncMock) as mock_get_store,
+        ):
+            mock_store = AsyncMock()
+            mock_store.get_one.side_effect = get_one_side_effect
+            mock_get_store.return_value = mock_store
+
+            mock_response = AsyncMock()
+            mock_response.status = 200
+            mock_response.read.return_value = b"""<?xml version="1.0" encoding="UTF-8"?>
+
+<msGMLOutput
+    xmlns:gml="http://www.opengis.net/gml"
+    xmlns:xlink="http://www.w3.org/1999/xlink"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+</msGMLOutput>
+"""
+            mock_response.headers = {"Content-Type": "application/xml"}
+            mock_get.return_value.__aenter__.return_value = mock_response
+
+            response = client.get("/tiles/1.0.0/nodim/default/swissgrid_5/1/11/14.png")
+            assert response.status_code == 200, response.text
+            assert response.headers["Content-Type"] == "image/png"
+            assert response.content == b"dummy_png"
+
+            response = client.get(
+                "/tiles/1.0.0/nodim/default/swissgrid_5/1/11/14/114/111.xml",
+                params={
+                    "Info_Format": "application/vnd.ogc.gml",
+                },
+            )
+            assert response.status_code == 200, response.text
+            self.assert_result_equals(
+                response.text,
+                """<?xml version="1.0" encoding="UTF-8"?>
+
+<msGMLOutput
+    xmlns:gml="http://www.opengis.net/gml"
+    xmlns:xlink="http://www.w3.org/1999/xlink"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+</msGMLOutput>
+""",
             )
 
     @pytest.mark.asyncio

--- a/tilecloud_chain/tests/tilegeneration/test-nodim.yaml
+++ b/tilecloud_chain/tests/tilegeneration/test-nodim.yaml
@@ -6,12 +6,13 @@ grids:
     srs: EPSG:21781
 
 caches:
-  s3:
-    type: s3
-    http_url: https://%(host)s/%(bucket)s/%(folder)s/
-    host: s3-eu-west-1.amazonaws.com
-    bucket: tiles
-    folder: tiles
+  local:
+    type: filesystem
+    http_url: http://wmts1/tiles/
+    folder: /tmp/tiles
+
+generation:
+  default_cache: local
 
 defaults:
   layer: &layer
@@ -33,3 +34,7 @@ layers:
   nodim:
     <<: *layer
     layers: default
+    query_layers: default
+
+server:
+  layers: [nodim]

--- a/tilecloud_chain/views/admin.py
+++ b/tilecloud_chain/views/admin.py
@@ -58,7 +58,7 @@ _postgresql_store: tilecloud_chain.store.postgresql.PostgresqlTileStore | None =
 app = FastAPI(title="TileCloud-chain admin API")
 
 
-def _get_tilegeneration() -> TileGeneration:
+async def _get_tilegeneration() -> TileGeneration:
     """Get the tilegeneration instance."""
     if (
         not hasattr(tilecloud_chain.server, "_TILEGENERATION")
@@ -71,14 +71,14 @@ def _get_tilegeneration() -> TileGeneration:
 async def startup(_main_app: FastAPI) -> None:
     """Create and configure the FastAPI admin application."""
 
-    main_config = await _get_tilegeneration().get_main_config()
+    main_config = await (await _get_tilegeneration()).get_main_config()
     queue_store = main_config.config.get("queue_store", configuration.QUEUE_STORE_DEFAULT)
     if queue_store == "postgresql":
         global _postgresql_store  # noqa: PLW0603
         _postgresql_store = await tilecloud_chain.store.postgresql.get_postgresql_queue_store(main_config)
 
 
-def _get_postgresql_store() -> tilecloud_chain.store.postgresql.PostgresqlTileStore:
+async def _get_postgresql_store() -> tilecloud_chain.store.postgresql.PostgresqlTileStore:
     """Get the PostgreSQL store."""
     if not _postgresql_store:
         raise HTTPException(status_code=400, detail="PostgreSQL queue store not configured")
@@ -107,7 +107,7 @@ async def _get_access(
     )
 
 
-def _check_access(
+async def _check_access(
     has_access: Annotated[dict[str, Any], Depends(_get_access)],
 ) -> None:
     """Check if the user has access to admin functions."""


### PR DESCRIPTION
## Problem

FastAPI's `{param:path}` greedy matcher requires at least one path segment, so a WMTS REST request for a layer without dimensions:

```
GET /tiles/1.0.0/ortsplan/default/2056/3/0/0.png
```

did not match the existing route pattern:

```
/{version}/{layer}/{style}/{dimensions_parameters:path}/{tilematrixset}/{tilematrix}/{tilerow}/{tilecol}.{extension}
```

and FastAPI returned 404.

## Solution

Add dedicated routes without the `{dimensions_parameters:path}` segment for both `GetTile` and `GetFeatureInfo` (with and without `.xml` suffix). The no-dimension routes are declared before the greedy ones so FastAPI matches them first.

A layer with configured dimensions called via the no-dimension route returns HTTP 400 with an explicit error message.

## Refactoring

Three shared FastAPI dependencies are extracted to eliminate duplication across the four handlers:

- `_get_layer_obj`: validates the layer name and returns the cast `layer_obj`
- `_get_tile_params`: builds the base `GetTile` params dict and maps the file extension to a `FORMAT` MIME type
- `_get_feature_info_params`: builds the base `GetFeatureInfo` params dict (reuses `_get_layer_obj` via `Depends`)

Each handler now only contains its distinctive logic before delegating to `server.serve()`.