### PR TITLE
Audit Snyk check/fix 1.21

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -2,6 +2,10 @@
 version: v1.25.1
 # ignores vulnerabilities until expiry date; change duration by modifying expiry date
 ignore:
+  SNYK-PYTHON-DULWICH-17266106:
+    - '*':
+        reason: not compatible with used Poetry version
+        created: 2026-06-10T12:10:12.000Z
   SNYK-PYTHON-DULWICH-17054926:
     - '*':
         reason: not compatible with used Poetry version


### PR DESCRIPTION
Replace incompatible dulwich pin handling by CVE ignore in `.snyk` while keeping existing ignore entries.