### PR TITLE
Propagate metatile errors on tile write failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 - Show a clear admin error message when a generation command fails before producing output (for example, an unknown grid), and clarify PostgreSQL job ETA text with explicit units like `2 days 2 hours`.
 - Fix PostgreSQL admin retry action so it requeues only errored meta tiles instead of restarting full queue seeding for the whole job.
 - Add Python 3.14 support and use the PyPI Mapnik bindings instead of the removed Ubuntu `python3-mapnik` package.
+- Mark PostgreSQL metatile queue entries as `error` (instead of deleting them) when a child tile fails during write/store, so generation failures are visible in job status.
 
 Environment variable migration (legacy -> new)
 

--- a/tilecloud_chain/__init__.py
+++ b/tilecloud_chain/__init__.py
@@ -341,6 +341,8 @@ class Run:
                     if self.gene.queue_store is not None:
                         if hasattr(tile, "metatile"):
                             metatile: Tile = tile.metatile
+                            if not metatile.error:
+                                metatile.error = tile.error
                             metatile.elapsed_togenerate -= 1  # type: ignore[attr-defined]
                             if metatile.elapsed_togenerate == 0:  # type: ignore[attr-defined]
                                 await self.gene.queue_store.delete_one(metatile)

--- a/tilecloud_chain/tests/test_error.py
+++ b/tilecloud_chain/tests/test_error.py
@@ -284,6 +284,7 @@ async def test_run_delete_metatile_on_error() -> None:
     await run(child_tile)
 
     assert queue_store.deleted == [metatile]
+    assert metatile.error == "boom"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
This change ensures write failures on child tiles are propagated to their parent metatile before queue cleanup.

- set `metatile.error` from child tile errors in the run pipeline
- keep existing metatile completion/dequeue logic
- add a regression assertion in `test_run_delete_metatile_on_error`

This makes PostgreSQL queue entries end in `error` status instead of being deleted when a child tile write fails (for example on filesystem `PermissionError`).