### PR TITLE
Remove wmts_path setting, use route_prefix instead

### DIFF
--- a/example/tilegeneration/config-postgresql.yaml
+++ b/example/tilegeneration/config-postgresql.yaml
@@ -23,7 +23,7 @@ caches:
     type: filesystem
     folder: /var/sig/tiles
     # for GetCapabilities
-    http_url: http://%(host)s/tiles/
+    http_url: http://%(host)s/
     hosts:
       - localhost:9052
   s3:

--- a/example/tilegeneration/config.yaml
+++ b/example/tilegeneration/config.yaml
@@ -13,7 +13,7 @@ caches:
     type: filesystem
     folder: /var/sig/tiles
     # for GetCapabilities
-    http_url: https://%(host)s/tiles/
+    http_url: https://%(host)s/
     hosts:
       - wmts0.example.com
       - wmts1.example.com

--- a/tilecloud_chain/CONFIG.md
+++ b/tilecloud_chain/CONFIG.md
@@ -311,7 +311,7 @@
   - <a id="definitions/server/properties/geoms_redirect"></a>**`geoms_redirect`** *(boolean)*: Take care on the geometries. Default: `false`.
   - <a id="definitions/server/properties/static_allow_extension"></a>**`static_allow_extension`** *(array)*: The allowed extension of static files. Default: `["jpeg", "png", "xml", "js", "html", "css"]`.
     - <a id="definitions/server/properties/static_allow_extension/items"></a>**Items** *(string)*
-  - <a id="definitions/server/properties/wmts_path"></a>**`wmts_path`** *(string)*: No more used, replaced by `TILECLOUD_CHAIN__WMTS_PATH` environment variable.
+  - <a id="definitions/server/properties/wmts_path"></a>**`wmts_path`** *(string)*: No longer used, replaced by `TILECLOUD_CHAIN__ROUTE_PREFIX` environment variable.
   - <a id="definitions/server/properties/expires"></a>**`expires`** *(integer)*: The browser cache expiration in hours. Default: `8`.
   - <a id="definitions/server/properties/predefined_commands"></a>**`predefined_commands`** *(array)*: The predefined commands used to generate the tiles.
     - <a id="definitions/server/properties/predefined_commands/items"></a>**Items** *(object)*: Cannot contain additional properties.

--- a/tilecloud_chain/configuration.py
+++ b/tilecloud_chain/configuration.py
@@ -2936,7 +2936,7 @@ class Server(TypedDict, total=False):
     r"""
     WMTS path.
 
-    No more used, replaced by `TILECLOUD_CHAIN__WMTS_PATH` environment variable
+    No longer used, replaced by `TILECLOUD_CHAIN__ROUTE_PREFIX` environment variable
     """
 
     expires: int

--- a/tilecloud_chain/schema.json
+++ b/tilecloud_chain/schema.json
@@ -1176,7 +1176,7 @@
         },
         "wmts_path": {
           "title": "WMTS path",
-          "description": "No more used, replaced by `TILECLOUD_CHAIN__WMTS_PATH` environment variable",
+          "description": "No longer used, replaced by `TILECLOUD_CHAIN__ROUTE_PREFIX` environment variable",
           "type": "string"
         },
         "expires": {

--- a/tilecloud_chain/server.py
+++ b/tilecloud_chain/server.py
@@ -165,7 +165,7 @@ def _add_dimensions_to_params(
         params[dimension["name"].upper()] = provided_dimension_values[index]
 
 
-async def init_tilegeneration(config_file: Path | None) -> None:
+async def _init_tile_generation(config_file: Path | None) -> None:
     """Initialize the tile generation."""
     global _TILEGENERATION  # noqa: PLW0603
     if _TILEGENERATION is None:
@@ -504,7 +504,7 @@ class Server:
 
                 base_urls = [ending_slash(url) for url in base_urls]
 
-                await _fill_legend(cache, base_urls[0], config=config)
+                await _fill_legend(cache, f"{base_urls[0]}{settings.route_prefix[1:]}", config=config)
 
                 return _TEMPLATES.TemplateResponse(
                     "wmts_get_capabilities.jinja",
@@ -515,7 +515,7 @@ class Server:
                         "layer_legends": _TILEGENERATION.layer_legends,
                         "grids": config.config["grids"],
                         "base_urls": base_urls,
-                        "base_url_postfix": settings.wmts_path,
+                        "base_url_postfix": settings.route_prefix[1:],
                         "get_tile_matrix_identifier": get_tile_matrix_identifier,
                         "server": server_config is not None,
                         "has_metadata": "metadata" in config.config,
@@ -823,13 +823,13 @@ class Server:
 server = Server()
 router = fastapi.APIRouter()
 
-route_prefix = f"{settings.route_prefix}{settings.wmts_path}"
+route_prefix = settings.route_prefix
 
 
 async def startup(_main_app: FastAPI) -> None:
     """Initialize the FastAPI app."""
     config_file = settings.config_file
-    await init_tilegeneration(config_file)
+    await _init_tile_generation(config_file)
 
 
 async def get_host_name(request: Request) -> str:

--- a/tilecloud_chain/settings.py
+++ b/tilecloud_chain/settings.py
@@ -50,15 +50,6 @@ def _to_route_prefix(route_prefix: str) -> str:
 RoutePrefix = Annotated[str, BeforeValidator(_to_route_prefix)]
 
 
-def _to_wmts_path(wmts_path: str) -> str:
-    if wmts_path and not wmts_path.endswith("/"):
-        wmts_path = f"{wmts_path}/"
-    return wmts_path
-
-
-WMTSPath = Annotated[str, BeforeValidator(_to_wmts_path)]
-
-
 class AzureSettings(BaseModel):
     """Azure storage settings."""
 
@@ -146,7 +137,6 @@ class Settings(BaseSettings):
     frontend: str | None = None
     development: bool = False
     route_prefix: RoutePrefix = "/tiles/"
-    wmts_path: WMTSPath = ""
 
     azure: AzureSettings = AzureSettings()
     logging: LoggingSettings = LoggingSettings()

--- a/tilecloud_chain/tests/test_controller.py
+++ b/tilecloud_chain/tests/test_controller.py
@@ -1242,11 +1242,11 @@ class TestController(CompareCase):
 caches:
   local:
     folder: /tmp/tiles
-    http_url: http://wmts1/tiles/
+    http_url: http://wmts1/
     type: filesystem
   mbtiles:
     folder: /tmp/tiles/mbtiles
-    http_url: http://wmts1/tiles/
+    http_url: http://wmts1/
     type: mbtiles
   multi_host:
     folder: /tmp/tiles
@@ -1254,14 +1254,14 @@ caches:
     - wmts1
     - wmts2
     - wmts3
-    http_url: http://%(host)s/tiles/
+    http_url: http://%(host)s/
     type: filesystem
   multi_url:
     folder: /tmp/tiles
     http_urls:
-    - http://wmts1/tiles/
-    - http://wmts2/tiles/
-    - http://wmts3/tiles/
+    - http://wmts1/
+    - http://wmts2/
+    - http://wmts3/
     type: filesystem
   s3:
     bucket: tiles

--- a/tilecloud_chain/tests/tilegeneration/test-bsddb.yaml
+++ b/tilecloud_chain/tests/tilegeneration/test-bsddb.yaml
@@ -8,7 +8,7 @@ grids:
 caches:
   bsddb:
     type: bsddb
-    http_url: http://wmts1/tiles/
+    http_url: http://wmts1/
     folder: /tmp/tiles/bsddb
     wmtscapabilities_file: 1.0.0/WMTSCapabilities.xml
 

--- a/tilecloud_chain/tests/tilegeneration/test-capabilities.yaml
+++ b/tilecloud_chain/tests/tilegeneration/test-capabilities.yaml
@@ -8,7 +8,7 @@ grids:
 caches:
   local:
     type: filesystem
-    http_url: http://wmts1/tiles/
+    http_url: http://wmts1/
     folder: /tmp/tiles
 
 defaults:

--- a/tilecloud_chain/tests/tilegeneration/test-fix.yaml
+++ b/tilecloud_chain/tests/tilegeneration/test-fix.yaml
@@ -29,11 +29,11 @@ grids:
 caches:
   local:
     type: filesystem
-    http_url: http://wmts1/tiles/
+    http_url: http://wmts1/
     folder: /tmp/tiles
   multi_host:
     type: filesystem
-    http_url: http://%(host)s/tiles/
+    http_url: http://%(host)s/
     folder: /tmp/tiles
     hosts:
       - wmts1
@@ -42,13 +42,13 @@ caches:
   multi_url:
     type: filesystem
     http_urls:
-      - http://wmts1/tiles/
-      - http://wmts2/tiles/
-      - http://wmts3/tiles/
+      - http://wmts1/
+      - http://wmts2/
+      - http://wmts3/
     folder: /tmp/tiles
   mbtiles:
     type: mbtiles
-    http_url: http://wmts1/tiles/
+    http_url: http://wmts1/
     folder: /tmp/tiles/mbtiles
   s3:
     type: s3

--- a/tilecloud_chain/tests/tilegeneration/test-int-grid.yaml
+++ b/tilecloud_chain/tests/tilegeneration/test-int-grid.yaml
@@ -8,7 +8,7 @@ grids:
 caches:
   bsddb:
     type: bsddb
-    http_url: http://wmts1/tiles/
+    http_url: http://wmts1/
     folder: /tmp/tiles/bsddb
 
 defaults:

--- a/tilecloud_chain/tests/tilegeneration/test-internal-mapcache.yaml
+++ b/tilecloud_chain/tests/tilegeneration/test-internal-mapcache.yaml
@@ -8,7 +8,7 @@ grids:
 caches:
   local:
     type: filesystem
-    http_url: http://wmts1/tiles/
+    http_url: http://wmts1/
     folder: /tmp/tiles
     wmtscapabilities_file: 1.0.0/WMTSCapabilities.xml
 

--- a/tilecloud_chain/tests/tilegeneration/test-legends-items.yaml
+++ b/tilecloud_chain/tests/tilegeneration/test-legends-items.yaml
@@ -8,7 +8,7 @@ grids:
 caches:
   local:
     type: filesystem
-    http_url: http://wmts1/tiles/
+    http_url: http://wmts1/
     folder: /tmp/tiles
 
 defaults:

--- a/tilecloud_chain/tests/tilegeneration/test-legends.yaml
+++ b/tilecloud_chain/tests/tilegeneration/test-legends.yaml
@@ -8,7 +8,7 @@ grids:
 caches:
   local:
     type: filesystem
-    http_url: http://wmts1/tiles/
+    http_url: http://wmts1/
     folder: /tmp/tiles
 
 defaults:

--- a/tilecloud_chain/tests/tilegeneration/test-multi-grid.yaml
+++ b/tilecloud_chain/tests/tilegeneration/test-multi-grid.yaml
@@ -13,7 +13,7 @@ grids:
 caches:
   local:
     type: filesystem
-    http_url: http://wmts1/tiles/
+    http_url: http://wmts1/
     folder: /tmp/tiles
 
 defaults:

--- a/tilecloud_chain/tests/tilegeneration/test-multidim.yaml
+++ b/tilecloud_chain/tests/tilegeneration/test-multidim.yaml
@@ -8,7 +8,7 @@ grids:
 caches:
   local:
     type: filesystem
-    http_url: http://wmts1/tiles/
+    http_url: http://wmts1/
     folder: /tmp/tiles
     wmtscapabilities_file: 1.0.0/WMTSCapabilities.xml
 

--- a/tilecloud_chain/tests/tilegeneration/test-multigeom.yaml
+++ b/tilecloud_chain/tests/tilegeneration/test-multigeom.yaml
@@ -8,7 +8,7 @@ grids:
 caches:
   local:
     type: filesystem
-    http_url: http://wmts1/tiles/
+    http_url: http://wmts1/
     folder: /tmp/tiles
     wmtscapabilities_file: 1.0.0/WMTSCapabilities.xml
 

--- a/tilecloud_chain/tests/tilegeneration/test-no-legends.yaml
+++ b/tilecloud_chain/tests/tilegeneration/test-no-legends.yaml
@@ -8,7 +8,7 @@ grids:
 caches:
   local:
     type: filesystem
-    http_url: http://wmts1/tiles/
+    http_url: http://wmts1/
     folder: /tmp/tiles
 
 defaults:

--- a/tilecloud_chain/tests/tilegeneration/test-nodim.yaml
+++ b/tilecloud_chain/tests/tilegeneration/test-nodim.yaml
@@ -8,7 +8,7 @@ grids:
 caches:
   local:
     type: filesystem
-    http_url: http://wmts1/tiles/
+    http_url: http://wmts1/
     folder: /tmp/tiles
 
 generation:

--- a/tilecloud_chain/tests/tilegeneration/test-nosns.yaml
+++ b/tilecloud_chain/tests/tilegeneration/test-nosns.yaml
@@ -29,11 +29,11 @@ grids:
 caches:
   local:
     type: filesystem
-    http_url: http://wmts1/tiles/
+    http_url: http://wmts1/
     folder: /tmp/tiles
   multi_host:
     type: filesystem
-    http_url: http://%(host)s/tiles/
+    http_url: http://%(host)s/
     folder: /tmp/tiles
     hosts:
       - wmts1
@@ -42,17 +42,17 @@ caches:
   multi_url:
     type: filesystem
     http_urls:
-      - http://wmts1/tiles/
-      - http://wmts2/tiles/
-      - http://wmts3/tiles/
+      - http://wmts1/
+      - http://wmts2/
+      - http://wmts3/
     folder: /tmp/tiles
   mbtiles:
     type: mbtiles
-    http_url: http://wmts1/tiles/
+    http_url: http://wmts1/
     folder: /tmp/tiles/mbtiles
   bsddb:
     type: bsddb
-    http_url: http://wmts1/tiles/
+    http_url: http://wmts1/
     folder: /tmp/tiles/bsddb
   s3:
     type: s3

--- a/tilecloud_chain/tests/tilegeneration/test-postgresql.yaml
+++ b/tilecloud_chain/tests/tilegeneration/test-postgresql.yaml
@@ -10,7 +10,7 @@ grids:
 caches:
   local:
     type: filesystem
-    http_url: http://wmts1/tiles/
+    http_url: http://wmts1/
     folder: /tmp/tiles
     wmtscapabilities_file: 1.0.0/WMTSCapabilities.xml
 

--- a/tilecloud_chain/tests/tilegeneration/test-redis-project.yaml
+++ b/tilecloud_chain/tests/tilegeneration/test-redis-project.yaml
@@ -8,7 +8,7 @@ grids:
 caches:
   local:
     type: filesystem
-    http_url: http://wmts1/tiles/
+    http_url: http://wmts1/
     folder: /tmp/tiles
     wmtscapabilities_file: 1.0.0/WMTSCapabilities.xml
 

--- a/tilecloud_chain/tests/tilegeneration/test-redis.yaml
+++ b/tilecloud_chain/tests/tilegeneration/test-redis.yaml
@@ -8,7 +8,7 @@ grids:
 caches:
   local:
     type: filesystem
-    http_url: http://wmts1/tiles/
+    http_url: http://wmts1/
     folder: /tmp/tiles
     wmtscapabilities_file: 1.0.0/WMTSCapabilities.xml
 

--- a/tilecloud_chain/tests/tilegeneration/test-serve-wmtscapabilities.yaml
+++ b/tilecloud_chain/tests/tilegeneration/test-serve-wmtscapabilities.yaml
@@ -8,7 +8,7 @@ grids:
 caches:
   local:
     type: filesystem
-    http_url: http://wmts1/tiles/
+    http_url: http://wmts1/
     folder: /tmp/tiles-ondemend
 
 defaults:

--- a/tilecloud_chain/tests/tilegeneration/test-serve.yaml
+++ b/tilecloud_chain/tests/tilegeneration/test-serve.yaml
@@ -8,11 +8,11 @@ grids:
 caches:
   local:
     type: filesystem
-    http_url: http://wmts1/tiles/
+    http_url: http://wmts1/
     folder: /tmp/tiles
   mbtiles:
     type: mbtiles
-    http_url: http://wmts1/tiles/
+    http_url: http://wmts1/
     folder: /tmp/tiles/mbtiles
 
 defaults:

--- a/tilecloud_chain/tests/tilegeneration/test.yaml
+++ b/tilecloud_chain/tests/tilegeneration/test.yaml
@@ -29,12 +29,12 @@ grids:
 caches:
   local:
     type: filesystem
-    http_url: http://wmts1/tiles/
+    http_url: http://wmts1/
     folder: /tmp/tiles
     wmtscapabilities_file: 1.0.0/WMTSCapabilities.xml
   multi_host:
     type: filesystem
-    http_url: http://%(host)s/tiles/
+    http_url: http://%(host)s/
     folder: /tmp/tiles
     hosts:
       - wmts1
@@ -43,17 +43,17 @@ caches:
   multi_url:
     type: filesystem
     http_urls:
-      - http://wmts1/tiles/
-      - http://wmts2/tiles/
-      - http://wmts3/tiles/
+      - http://wmts1/
+      - http://wmts2/
+      - http://wmts3/
     folder: /tmp/tiles
   mbtiles:
     type: mbtiles
-    http_url: http://wmts1/tiles/
+    http_url: http://wmts1/
     folder: /tmp/tiles/mbtiles
   bsddb:
     type: bsddb
-    http_url: http://wmts1/tiles/
+    http_url: http://wmts1/
     folder: /tmp/tiles/bsddb
   s3:
     type: s3


### PR DESCRIPTION
The `wmts_path` setting (env `TILECLOUD_CHAIN__WMTS_PATH`) was an optional sub-path duplicated from `route_prefix`. Now `route_prefix` is used directly for both the WMTS route prefix and the `base_url_postfix` in the GetCapabilities template (without leading slash to avoid double slashes).

The `wmts_path` field is kept in `schema.json` for backward compatibility.

Migration: users who set `wmts_path` should move its value to `route_prefix` and adjust the `http_url` in their cache config accordingly.