### PR TITLE
Restore static route for legend images

### DIFF
--- a/tilecloud_chain/USAGE.rst
+++ b/tilecloud_chain/USAGE.rst
@@ -610,7 +610,7 @@ The server can be configure as it:
         cache: mbtiles # The used cache [default use generation/default_cache]
         # the URL without location to MapCache, [default is http://localhost/]
         geoms_redirect: true # use the geoms to redirect to MapCache [default is false]
-        # allowed extension in the static path (default value), not used for s3.
+        # allowed extensions in the static path (default value).
         static_allow_extension: [jpeg, png, xml, js, html, css]
 
 The minimal configuration is to enable it:

--- a/tilecloud_chain/internal_mapcache.py
+++ b/tilecloud_chain/internal_mapcache.py
@@ -317,8 +317,6 @@ async def fetch(
             + datetime.timedelta(hours=server.get_expires_hours(config))
         ).isoformat(),
         "Cache-Control": f"max-age={3600 * server.get_expires_hours(config)}",
-        "Access-Control-Allow-Origin": "*",
-        "Access-Control-Allow-Methods": "GET",
         "Tile-Backend": backend,
     }
     if fetched_tile.content_encoding:

--- a/tilecloud_chain/main.py
+++ b/tilecloud_chain/main.py
@@ -173,6 +173,24 @@ app.add_middleware(
                 "Cross-Origin-Resource-Policy": "cross-origin",
             },
         },
+        "kvp": {
+            "path_match": r"^$",
+            "headers": {
+                "Access-Control-Allow-Methods": "GET",
+                "Access-Control-Allow-Origin": "*",
+                "Access-Control-Allow-Credentials": None,
+                "Cross-Origin-Resource-Policy": "cross-origin",
+            },
+        },
+        "static": {
+            "path_match": rf"^{route_prefix_escaped}static/.*$",
+            "headers": {
+                "Access-Control-Allow-Methods": "GET",
+                "Access-Control-Allow-Origin": "*",
+                "Access-Control-Allow-Credentials": None,
+                "Cross-Origin-Resource-Policy": "cross-origin",
+            },
+        },
     },
 )
 
@@ -207,7 +225,9 @@ async def redirect_c2c(request: Request) -> RedirectResponse:
 
 # Add Routers
 # Mount the most specific routes first to ensure correct routing precedence.
-app.mount(f"{route_prefix}static", StaticFiles(directory=Path(__file__).parent / "static"), name="static")
+app.mount(
+    f"{route_prefix}tcc_static", StaticFiles(directory=Path(__file__).parent / "static"), name="tcc_static"
+)
 app.include_router(server.router, tags=["wmts"])  # WMTS routes
 app.mount(f"{route_prefix}c2c", c2casgiutils.app)  # C2C utility routes
 app.mount(f"{route_prefix}admin", admin.app)  # Admin routes

--- a/tilecloud_chain/server.py
+++ b/tilecloud_chain/server.py
@@ -368,7 +368,7 @@ class Server:
                 return self.error(config, 404, key_name + " not found")
             raise
 
-    async def _get(
+    async def get(
         self,
         path: str,
         headers: dict[str, str],
@@ -475,13 +475,11 @@ class Server:
                         + datetime.timedelta(hours=self.get_expires_hours(config))
                     ).isoformat(),
                     "Cache-Control": f"max-age={3600 * self.get_expires_hours(config)}",
-                    "Access-Control-Allow-Origin": "*",
-                    "Access-Control-Allow-Methods": "GET",
                 }
                 cache = self.get_cache(config)
                 if "wmtscapabilities_file" in cache:
                     wmtscapabilities_file = cache["wmtscapabilities_file"]
-                    return await self._get(wmtscapabilities_file, headers, config=config)
+                    return await self.get(wmtscapabilities_file, headers, config=config)
 
                 cache_name: str = self.get_cache_name(config)
                 if config is None:
@@ -504,7 +502,7 @@ class Server:
 
                 base_urls = [ending_slash(url) for url in base_urls]
 
-                await _fill_legend(cache, f"{base_urls[0]}{settings.route_prefix[1:]}", config=config)
+                await _fill_legend(cache, f"{base_urls[0]}{settings.route_prefix[1:]}static/", config=config)
 
                 return _TEMPLATES.TemplateResponse(
                     "wmts_get_capabilities.jinja",
@@ -707,8 +705,6 @@ class Server:
                         + datetime.timedelta(hours=self.get_expires_hours(config))
                     ).isoformat(),
                     "Cache-Control": f"max-age={3600 * self.get_expires_hours(config)}",
-                    "Access-Control-Allow-Origin": "*",
-                    "Access-Control-Allow-Methods": "GET",
                     "Tile-Backend": "Cache",
                 },
             )
@@ -776,8 +772,6 @@ class Server:
                         + datetime.timedelta(hours=self.get_expires_hours(config))
                     ).isoformat()
                     response_headers["Cache-Control"] = f"max-age={3600 * self.get_expires_hours(config)}"
-                    response_headers["Access-Control-Allow-Origin"] = "*"
-                    response_headers["Access-Control-Allow-Methods"] = "GET"
                 content = await response.read()
                 return Response(content=content, headers=response_headers)
             safe_reason = (
@@ -803,10 +797,7 @@ class Server:
         message: Exception | str | None = "",
     ) -> Response:
         """Build the FastAPI error response."""
-        headers = {
-            "Access-Control-Allow-Origin": "*",
-            "Access-Control-Allow-Methods": "GET",
-        }
+        headers: dict[str, str] = {}
         if code < 300:
             headers.update(
                 {
@@ -1202,6 +1193,40 @@ async def wmts_kvp(
         )
 
     return await server.serve(params, config, host, fastapi_request)
+
+
+@router.get(
+    f"{route_prefix}static/{{path:path}}",
+    summary="Get static files from the cache.",
+)
+async def get_static(
+    path: str,
+    config: Annotated[tilecloud_chain.DatedConfig, fastapi.Depends(get_host_config)],
+) -> Response:
+    """Get static files from the cache."""
+    if not config.config:
+        raise HTTPException(
+            status_code=404,
+            detail="No configuration file found for the host or the configuration has an error, see logs for details",
+        )
+    # Defensive checks: FastAPI `{path:path}` may contain traversal segments.
+    if "\\" in path or any(part in {"", ".", ".."} for part in path.split("/")):
+        return server.error(config, 400, "Invalid path")
+
+    allowed_extensions = {e.lower() for e in server.get_static_allow_extension(config)}
+    filename = path.rsplit("/", maxsplit=1)[-1]
+    ext = filename.rsplit(".", maxsplit=1)[-1].lower() if "." in filename else ""
+    if not ext or ext not in allowed_extensions:
+        return server.error(config, 403, "Extension not allowed")
+
+    headers: dict[str, str] = {
+        "Expires": (
+            datetime.datetime.now(tz=datetime.UTC)
+            + datetime.timedelta(hours=server.get_expires_hours(config))
+        ).isoformat(),
+        "Cache-Control": f"max-age={3600 * server.get_expires_hours(config)}",
+    }
+    return await server.get(path, headers, config=config)
 
 
 def _get_base_urls(cache: tilecloud_chain.configuration.Cache) -> list[str]:

--- a/tilecloud_chain/tests/test_controller.py
+++ b/tilecloud_chain/tests/test_controller.py
@@ -1976,9 +1976,9 @@ sqs:
       <ows:Identifier>all</ows:Identifier>
       <Style isDefault="true">
         <ows:Identifier>default</ows:Identifier>
-        <LegendURL format="image/png" xlink:href="http://wmts1/tiles/1.0.0/all/default/legend-5.png" """
+        <LegendURL format="image/png" xlink:href="http://wmts1/tiles/static/1.0.0/all/default/legend-5.png" """
             """width="[0-9]*" height="[0-9]*" maxScaleDenominator="56469.24393[0-9]*" />
-        <LegendURL format="image/png" xlink:href="http://wmts1/tiles/1.0.0/all/default/legend-50.png" """
+        <LegendURL format="image/png" xlink:href="http://wmts1/tiles/static/1.0.0/all/default/legend-50.png" """
             """width="[0-9]*" height="[0-9]*" minScaleDenominator="56469.24393[0-9]*" />
       </Style>
       <Format>image/png</Format>
@@ -2039,9 +2039,9 @@ sqs:
       <ows:Identifier>line</ows:Identifier>
       <Style isDefault="true">
         <ows:Identifier>default</ows:Identifier>
-        <LegendURL format="image/png" xlink:href="http://wmts1/tiles/1.0.0/line/default/legend-5.png" """
+        <LegendURL format="image/png" xlink:href="http://wmts1/tiles/static/1.0.0/line/default/legend-5.png" """
             r"""width="[0-9]*" height="[0-9]*" maxScaleDenominator="56469.24393[0-9]*" />
-        <LegendURL format="image/png" xlink:href="http://wmts1/tiles/1.0.0/line/default/legend-50.png" """
+        <LegendURL format="image/png" xlink:href="http://wmts1/tiles/static/1.0.0/line/default/legend-50.png" """
             r"""width="[0-9]*" height="[0-9]*" minScaleDenominator="56469.24393[0-9]*" />
       </Style>
       <Format>image/png</Format>
@@ -2065,7 +2065,7 @@ sqs:
       <ows:Identifier>point</ows:Identifier>
       <Style isDefault="true">
         <ows:Identifier>default</ows:Identifier>
-        <LegendURL format="image/png" xlink:href="http://wmts1/tiles/1.0.0/point/default/legend-5.png" """
+        <LegendURL format="image/png" xlink:href="http://wmts1/tiles/static/1.0.0/point/default/legend-5.png" """
             """width="[0-9]*" height="[0-9]*" />
       </Style>
       <Format>image/png</Format>
@@ -2089,7 +2089,7 @@ sqs:
       <ows:Identifier>polygon</ows:Identifier>
       <Style isDefault="true">
         <ows:Identifier>default</ows:Identifier>
-        <LegendURL format="image/png" xlink:href="http://wmts1/tiles/1.0.0/polygon/default/legend-5.png" """
+        <LegendURL format="image/png" xlink:href="http://wmts1/tiles/static/1.0.0/polygon/default/legend-5.png" """
             """width="[0-9]*" height="[0-9]*" />
       </Style>
       <Format>image/png</Format>

--- a/tilecloud_chain/tests/test_multi_grid.py
+++ b/tilecloud_chain/tests/test_multi_grid.py
@@ -296,7 +296,7 @@ Size per tile: [0-9]{3} o
       <ows:Identifier>all</ows:Identifier>
       <Style isDefault="true">
         <ows:Identifier>default</ows:Identifier>
-        <LegendURL format="image/png" xlink:href="http://wmts1/tiles/1.0.0/all/default/legend-5.png" width="64" height="20" />
+        <LegendURL format="image/png" xlink:href="http://wmts1/tiles/static/1.0.0/all/default/legend-5.png" width="64" height="20" />
       </Style>
       <Format>image/png</Format>
       <Dimension>
@@ -320,7 +320,7 @@ Size per tile: [0-9]{3} o
       <ows:Identifier>one</ows:Identifier>
       <Style isDefault="true">
         <ows:Identifier>default</ows:Identifier>
-        <LegendURL format="image/png" xlink:href="http://wmts1/tiles/1.0.0/one/default/legend-5.png" width="64" height="20" />
+        <LegendURL format="image/png" xlink:href="http://wmts1/tiles/static/1.0.0/one/default/legend-5.png" width="64" height="20" />
       </Style>
       <Format>image/png</Format>
       <Dimension>

--- a/tilecloud_chain/tests/test_serve.py
+++ b/tilecloud_chain/tests/test_serve.py
@@ -1549,3 +1549,39 @@ class TestServe(CompareCase):
         assert key_2056 != key_21781
         assert "swissgrid_2056" in key_2056
         assert "swissgrid_21781" in key_21781
+
+    @pytest.mark.asyncio
+    async def test_get_static(self) -> None:
+        from fastapi import FastAPI
+        from fastapi.testclient import TestClient
+
+        from tilecloud_chain.server import router
+
+        server._PYRAMID_SERVER = None
+        server.server.store_cache = {}
+        server._TILEGENERATION = TileGeneration(
+            config_file=AnyioPath("tilegeneration/test-serve.yaml"),
+            configure_logging=False,
+        )
+
+        app = FastAPI()
+        app.include_router(router)
+        client = TestClient(app)
+
+        png_content = b"\x89PNG\r\n\x1a\n" + b"\x00" * 20
+        tiles_dir = Path("/tmp/tiles/mbtiles")
+        tiles_dir.mkdir(parents=True, exist_ok=True)
+        (tiles_dir / "test-legend.png").write_bytes(png_content)
+
+        response = client.get("/tiles/static/test-legend.png")
+        assert response.status_code == 200
+        assert response.content == png_content
+
+        response = client.get("/tiles/static/test-legend.txt")
+        assert response.status_code == 403
+
+        response = client.get("/tiles/static/%2e%2e%2ftest-legend.png")
+        assert response.status_code == 400
+
+        response = client.get("/tiles/static/nonexistent.png")
+        assert response.status_code == 404


### PR DESCRIPTION
Restore the `static` view that serves legend images directly from the cache (S3, Azure, filesystem), which was conflicting with the built-in `StaticFiles` mount.

- Rename the existing `StaticFiles` mount from `{route_prefix}static` to `{route_prefix}tcc_static` (name `tcc_static`)
- Add new `GET {route_prefix}static/{path:path}` route serving files from the cache via `Server._get()`, filtered by `static_allow_extension`
- Update legend `href` generation in capabilities to point to the new static route