### PR TITLE
Reintroduce TILECLOUD_CHAIN__WMTS_PATH environment variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 2.0.0
 
 - Persist admin test map state in the URL on `/admin/test` with map position (`x`, `y`, `z`) and selected layer (`layer`).
+- Add `TILECLOUD_CHAIN__WMTS_PATH` environment variable to configure the path used in WMTS capabilities URLs, defaulting to the route prefix without a leading slash.
 - Add a Pydantic-based settings hierarchy for environment variables.
 - Update server, queue, admin, and generation code to read configuration from `tilecloud_chain.settings`.
 - Document the new nested environment variable scheme in `tilecloud_chain/USAGE.rst`.

--- a/tilecloud_chain/CONFIG.md
+++ b/tilecloud_chain/CONFIG.md
@@ -311,7 +311,7 @@
   - <a id="definitions/server/properties/geoms_redirect"></a>**`geoms_redirect`** *(boolean)*: Take care on the geometries. Default: `false`.
   - <a id="definitions/server/properties/static_allow_extension"></a>**`static_allow_extension`** *(array)*: The allowed extension of static files. Default: `["jpeg", "png", "xml", "js", "html", "css"]`.
     - <a id="definitions/server/properties/static_allow_extension/items"></a>**Items** *(string)*
-  - <a id="definitions/server/properties/wmts_path"></a>**`wmts_path`** *(string)*: No longer used, replaced by `TILECLOUD_CHAIN__ROUTE_PREFIX` environment variable.
+  - <a id="definitions/server/properties/wmts_path"></a>**`wmts_path`** *(string)*: No longer used, replaced by `TILECLOUD_CHAIN__ROUTE_PREFIX` or `TILECLOUD_CHAIN__WMTS_PATH` environment variable.
   - <a id="definitions/server/properties/admin_path"></a>**`admin_path`** *(string)*: No longer used.
   - <a id="definitions/server/properties/static_path"></a>**`static_path`** *(string)*: No longer used.
   - <a id="definitions/server/properties/expires"></a>**`expires`** *(integer)*: The browser cache expiration in hours. Default: `8`.

--- a/tilecloud_chain/USAGE.rst
+++ b/tilecloud_chain/USAGE.rst
@@ -876,6 +876,9 @@ Server:
 - ``TILECLOUD_CHAIN__ROUTE_PREFIX``: Base URL path for tile access
   (default: ``/tiles/``)
 
+- ``TILECLOUD_CHAIN__WMTS_PATH``: Path used in WMTS capabilities URLs, overrides the route prefix
+  (default: the value of ``TILECLOUD_CHAIN__ROUTE_PREFIX`` without a leading ``/``)
+
 Worker:
 
 - ``TILECLOUD_CHAIN__NB_TASKS``: Number of concurrent tasks to run in parallel

--- a/tilecloud_chain/configuration.py
+++ b/tilecloud_chain/configuration.py
@@ -2936,7 +2936,7 @@ class Server(TypedDict, total=False):
     r"""
     WMTS path.
 
-    No longer used, replaced by `TILECLOUD_CHAIN__ROUTE_PREFIX` environment variable
+    No longer used, replaced by `TILECLOUD_CHAIN__ROUTE_PREFIX` or `TILECLOUD_CHAIN__WMTS_PATH` environment variable
     """
 
     admin_path: str

--- a/tilecloud_chain/schema.json
+++ b/tilecloud_chain/schema.json
@@ -1176,7 +1176,7 @@
         },
         "wmts_path": {
           "title": "WMTS path",
-          "description": "No longer used, replaced by `TILECLOUD_CHAIN__ROUTE_PREFIX` environment variable",
+          "description": "No longer used, replaced by `TILECLOUD_CHAIN__ROUTE_PREFIX` or `TILECLOUD_CHAIN__WMTS_PATH` environment variable",
           "type": "string"
         },
         "admin_path": {

--- a/tilecloud_chain/server.py
+++ b/tilecloud_chain/server.py
@@ -501,6 +501,8 @@ class Server:
                     )
                 server_config = (await _TILEGENERATION.get_main_config()).config.get("server")
 
+                wmts_path = settings.wmts_path or settings.route_prefix[1:]
+
                 base_urls = _get_base_urls(cache)
 
                 def ending_slash(url: str) -> str:
@@ -509,7 +511,7 @@ class Server:
 
                 base_urls = [ending_slash(url) for url in base_urls]
 
-                await _fill_legend(cache, f"{base_urls[0]}{settings.route_prefix[1:]}static/", config=config)
+                await _fill_legend(cache, f"{base_urls[0]}{wmts_path}static/", config=config)
 
                 return _TEMPLATES.TemplateResponse(
                     "wmts_get_capabilities.jinja",
@@ -520,7 +522,7 @@ class Server:
                         "layer_legends": _TILEGENERATION.layer_legends,
                         "grids": config.config["grids"],
                         "base_urls": base_urls,
-                        "base_url_postfix": settings.route_prefix[1:],
+                        "base_url_postfix": wmts_path,
                         "get_tile_matrix_identifier": get_tile_matrix_identifier,
                         "server": server_config is not None,
                         "has_metadata": "metadata" in config.config,

--- a/tilecloud_chain/settings.py
+++ b/tilecloud_chain/settings.py
@@ -40,14 +40,27 @@ StrList = Annotated[list[str], BeforeValidator(_to_str_list)]
 
 
 def _to_route_prefix(route_prefix: str) -> str:
-    if route_prefix and not route_prefix.startswith("/"):
+    if not route_prefix:
+        return "/"
+    if not route_prefix.startswith("/"):
         route_prefix = f"/{route_prefix}"
-    if route_prefix and not route_prefix.endswith("/"):
+    if not route_prefix.endswith("/"):
         route_prefix = f"{route_prefix}/"
     return route_prefix
 
 
 RoutePrefix = Annotated[str, BeforeValidator(_to_route_prefix)]
+
+
+def _to_wmts_path(wmts_path: str) -> str:
+    if not wmts_path:
+        return ""
+    if not wmts_path.endswith("/"):
+        wmts_path = f"{wmts_path}/"
+    return wmts_path.lstrip("/")
+
+
+WmtsPath = Annotated[str, BeforeValidator(_to_wmts_path)]
 
 
 class AzureSettings(BaseModel):
@@ -137,6 +150,7 @@ class Settings(BaseSettings):
     frontend: str | None = None
     development: bool = False
     route_prefix: RoutePrefix = "/tiles/"
+    wmts_path: WmtsPath = ""
 
     azure: AzureSettings = AzureSettings()
     logging: LoggingSettings = LoggingSettings()


### PR DESCRIPTION
Reintroduce the `wmts_path` configuration as the `TILECLOUD_CHAIN__WMTS_PATH` environment variable, defaulting to the route prefix without leading slash, used for URL generation in WMTSCapabilities.