### PR TITLE
Pin mheap/json-schema-spell-checker to version v2.3.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,7 @@ repos:
     hooks:
       - id: integrity-updater
   - repo: https://github.com/mheap/json-schema-spell-checker
-    rev: main
+    rev: v2.3.0
     hooks:
       - id: json-schema-spell-checker
         files: tilecloud_chain/schema.json
@@ -37,7 +37,7 @@ repos:
           - --en-us
           - --spelling=.github/spell-ignore-words.txt
   - repo: https://github.com/mheap/json-schema-spell-checker
-    rev: main
+    rev: v2.3.0
     hooks:
       - id: json-schema-spell-checker
         files: tilecloud_chain/host-limit-schema.json


### PR DESCRIPTION
Pin the pre-commit hook `mheap/json-schema-spell-checker` from `main` to the tagged release `v2.3.0` for reproducible checks.