### PR TITLE
Fix unclosed aiohttp connector and client session warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 2.0.0
 
+- Fix unclosed aiohttp connector and client session warnings by properly closing Azure blob storage clients and aiohttp sessions in `URLTileStore` and `AzureStorageBlobTileStore`.
+
 - Persist admin test map state in the URL on `/admin/test` with map position (`x`, `y`, `z`) and selected layer (`layer`).
 - Add `TILECLOUD_CHAIN__WMTS_PATH` environment variable to configure the path used in WMTS capabilities URLs, defaulting to the route prefix without a leading slash.
 - Add a Pydantic-based settings hierarchy for environment variables.

--- a/tilecloud_chain/__init__.py
+++ b/tilecloud_chain/__init__.py
@@ -16,7 +16,15 @@ import sys
 import tempfile
 import time
 from argparse import ArgumentParser, Namespace
-from collections.abc import AsyncIterator, Awaitable, Callable, Iterable, Iterator
+from collections.abc import (
+    AsyncGenerator,
+    AsyncIterator,
+    Awaitable,
+    Callable,
+    Iterable,
+    Iterator,
+)
+from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from fractions import Fraction
 from hashlib import sha1
@@ -643,26 +651,36 @@ class TileFilter(logging.Filter):
         return True
 
 
-def get_azure_container_client(container: str) -> ContainerClient:
-    """Get the Azure blog storage client."""
+@asynccontextmanager
+async def get_azure_container_client(container: str) -> AsyncGenerator[ContainerClient, None]:
+    """Get the Azure blob storage client as an async context manager.
+
+    The context manager ensures the client session is properly closed.
+    """
     if settings.azure.storage_connection_string:
-        return BlobServiceClient.from_connection_string(
+        async with BlobServiceClient.from_connection_string(
             settings.azure.storage_connection_string,
-        ).get_container_client(container=container)
-    if settings.azure.storage_blob_container_url:
-        container_client = ContainerClient.from_container_url(settings.azure.storage_blob_container_url)
-        if settings.azure.storage_blob_validate_container_name:
-            assert container == container_client.container_name, (
-                f"Container name mismatch: {container} != {container_client.container_name}"
-            )
-        return container_client
-    if not settings.azure.storage_account_url:
-        message = "TILECLOUD_CHAIN__AZURE__STORAGE_ACCOUNT_URL is not configured"
-        raise ValueError(message)
-    return BlobServiceClient(
-        account_url=settings.azure.storage_account_url,
-        credential=DefaultAzureCredential(),  # type: ignore[arg-type]
-    ).get_container_client(container=container)
+        ) as blob_service_client:
+            yield blob_service_client.get_container_client(container=container)
+    elif settings.azure.storage_blob_container_url:
+        async with ContainerClient.from_container_url(
+            settings.azure.storage_blob_container_url
+        ) as container_client:
+            yield container_client
+    else:
+        if not settings.azure.storage_account_url:
+            message = "TILECLOUD_CHAIN__AZURE__STORAGE_ACCOUNT_URL is not configured"
+            raise ValueError(message)
+        async with BlobServiceClient(
+            account_url=settings.azure.storage_account_url,
+            credential=DefaultAzureCredential(),  # type: ignore[arg-type]
+        ) as blob_service_client:
+            container_client = blob_service_client.get_container_client(container=container)
+            if settings.azure.storage_blob_validate_container_name:
+                assert container == container_client.container_name, (
+                    f"Container name mismatch: {container} != {container_client.container_name}"
+                )
+            yield container_client
 
 
 def get_grid_name(
@@ -1331,7 +1349,7 @@ class TileGeneration:
             cache_tilestore = AzureStorageBlobTileStore(
                 tilelayout=layout,
                 cache_control=cache_azure.get("cache_control"),
-                container_client=get_azure_container_client(cache_azure["container"]),
+                container=cache_azure["container"],
             )
         elif cache["type"] == "mbtiles":
             metadata = {}

--- a/tilecloud_chain/controller.py
+++ b/tilecloud_chain/controller.py
@@ -152,17 +152,17 @@ async def _send(
     if cache["type"] == "azure":
         cache_azure = cast("tilecloud_chain.configuration.CacheAzure", cache)
         key_name = Path(cache["folder"]) / path
-        container = get_azure_container_client(cache_azure["container"])
-        blob = container.get_blob_client(str(key_name))
-        await blob.upload_blob(
-            data,
-            overwrite=True,
-            content_settings=ContentSettings(
-                content_type=mime_type,
-                content_encoding="utf-8",
-                cache_control=cache_azure["cache_control"],
-            ),
-        )
+        async with get_azure_container_client(cache_azure["container"]) as container:
+            blob = container.get_blob_client(str(key_name))
+            await blob.upload_blob(
+                data,
+                overwrite=True,
+                content_settings=ContentSettings(
+                    content_type=mime_type,
+                    content_encoding="utf-8",
+                    cache_control=cache_azure["cache_control"],
+                ),
+            )
     else:
         if isinstance(data, str):
             data = data.encode("utf-8")

--- a/tilecloud_chain/server.py
+++ b/tilecloud_chain/server.py
@@ -400,29 +400,30 @@ class Server:
             cache_azure = cast("tilecloud_chain.configuration.CacheAzure", cache)
             key_name = Path(cache_azure["folder"]) / path
             try:
-                with _GET_TILE.labels(storage="azure").time():
-                    blob = get_azure_container_client(container=cache_azure["container"]).get_blob_client(
-                        blob=str(key_name),
+                async with get_azure_container_client(container=cache_azure["container"]) as container_client:
+                    with _GET_TILE.labels(storage="azure").time():
+                        blob = container_client.get_blob_client(
+                            blob=str(key_name),
+                        )
+                    properties = await blob.get_blob_properties()
+                    data = await (await blob.download_blob()).readall()
+                    headers = {
+                        **headers,
+                        **(
+                            {"Content-Type": properties.content_settings.content_type}
+                            if properties.content_settings.content_type
+                            else {}
+                        ),
+                        **(
+                            {"Content-Encoding": properties.content_settings.content_encoding}
+                            if properties.content_settings.content_encoding
+                            else {}
+                        ),
+                    }
+                    return Response(
+                        content=data,
+                        headers=headers,
                     )
-                properties = await blob.get_blob_properties()
-                data = await (await blob.download_blob()).readall()
-                headers = {
-                    **headers,
-                    **(
-                        {"Content-Type": properties.content_settings.content_type}
-                        if properties.content_settings.content_type
-                        else {}
-                    ),
-                    **(
-                        {"Content-Encoding": properties.content_settings.content_encoding}
-                        if properties.content_settings.content_encoding
-                        else {}
-                    ),
-                }
-                return Response(
-                    content=data,
-                    headers=headers,
-                )
             except ResourceNotFoundError:
                 return self.error(config, 404, f"{path} not found", **kwargs)
         else:
@@ -1275,10 +1276,11 @@ async def _get(path: str, cache: tilecloud_chain.configuration.Cache) -> bytes |
         cache_azure = cast("tilecloud_chain.configuration.CacheAzure", cache)
         key_name = Path(cache["folder"]) / path
         try:
-            blob = get_azure_container_client(container=cache_azure["container"]).get_blob_client(
-                blob=str(key_name),
-            )
-            return await (await blob.download_blob()).readall()
+            async with get_azure_container_client(container=cache_azure["container"]) as container_client:
+                blob = container_client.get_blob_client(
+                    blob=str(key_name),
+                )
+                return await (await blob.download_blob()).readall()
         except ResourceNotFoundError:
             return None
     else:

--- a/tilecloud_chain/store/azure_storage_blob.py
+++ b/tilecloud_chain/store/azure_storage_blob.py
@@ -24,12 +24,14 @@ class AzureStorageBlobTileStore(AsyncTileStore):
         container_client: ContainerClient | None = None,
     ) -> None:
         """Initialize."""
+        self._blob_service_client: BlobServiceClient | None = None
         if container_client is None:
             if settings.azure.storage_connection_string:
                 assert container is not None
-                self.container_client = BlobServiceClient.from_connection_string(
+                self._blob_service_client = BlobServiceClient.from_connection_string(
                     settings.azure.storage_connection_string,
-                ).get_container_client(container=container)
+                )
+                self.container_client = self._blob_service_client.get_container_client(container=container)
             elif settings.azure.storage_blob_container_url:
                 self.container_client = ContainerClient.from_container_url(
                     settings.azure.storage_blob_container_url,
@@ -41,16 +43,23 @@ class AzureStorageBlobTileStore(AsyncTileStore):
                 if not settings.azure.storage_account_url:
                     message = "TILECLOUD_CHAIN__AZURE__STORAGE_ACCOUNT_URL is not configured"
                     raise ValueError(message)
-                self.container_client = BlobServiceClient(
+                self._blob_service_client = BlobServiceClient(
                     account_url=settings.azure.storage_account_url,
                     credential=DefaultAzureCredential(),  # type: ignore[arg-type]
-                ).get_container_client(container=container)
+                )
+                self.container_client = self._blob_service_client.get_container_client(container=container)
         else:
             self.container_client = container_client
 
         self.tilelayout = tilelayout
         self.dry_run = dry_run
         self.cache_control = cache_control
+
+    async def close(self) -> None:
+        """Close the Azure container client session."""
+        await self.container_client.close()
+        if self._blob_service_client is not None:
+            await self._blob_service_client.close()
 
     async def __contains__(self, tile: Tile) -> bool:
         """Return true if this store contains ``tile``."""

--- a/tilecloud_chain/store/url.py
+++ b/tilecloud_chain/store/url.py
@@ -45,6 +45,10 @@ class URLTileStore(AsyncTileStore):
         if headers is not None:
             self._session.headers.update(headers)
 
+    async def close(self) -> None:
+        """Close the aiohttp session."""
+        await self._session.close()
+
     async def _get_hosts_limit(self) -> host_limit.HostLimit:
         """Initialize the store."""
         host_limit_path = settings.hosts_limit


### PR DESCRIPTION
Fix unclosed aiohttp.ClientSession leaks causing 'Unclosed connector' and 'Unclosed client session' warnings from asyncio.

## Changes

- Convert `get_azure_container_client` to an async context manager that properly closes `BlobServiceClient` and `ContainerClient` on exit.
- Add `close()` to `URLTileStore` to close the `aiohttp.ClientSession`.
- Add `close()` to `AzureStorageBlobTileStore` to close both the container client and its parent blob service client. Also store a reference to the `BlobServiceClient` for proper cleanup.
- Update all Azure callers in `server.py`, `controller.py`, and `__init__.py` to use `async with get_azure_container_client(...)` to ensure proper cleanup on scope exit.
- Pass container name directly to `AzureStorageBlobTileStore` so it manages its own client lifecycle.
- Stop leaking the `BlobServiceClient` created by `from_connection_string()` and `BlobServiceClient(...)` in `get_azure_container_client`.

Fixes MUTUALIZE-2MY