### PR TITLE
Fix host limit validation validating _DatedConfig object instead of the config dictionary

### DIFF
--- a/tilecloud_chain/store/url.py
+++ b/tilecloud_chain/store/url.py
@@ -65,7 +65,7 @@ class URLTileStore(AsyncTileStore):
                     assert schema_data
                     errors, _ = jsonschema_validator.validate(
                         str(host_limit_path),
-                        cast("dict[str, Any]", self._hosts_limit),
+                        cast("dict[str, Any]", self._hosts_limit.config),
                         json.loads(schema_data),
                     )
 


### PR DESCRIPTION
Fix JSON schema validation error 'not of type object' when the hosts_limit file exists (https://camptocamp.sentry.io/issues/7593718548/).

## Change

`URLTileStore._get_hosts_limit()` was validating `self._hosts_limit` (the `_DatedConfig` wrapper object) against the JSON schema instead of `self._hosts_limit.config` (the actual configuration dictionary). The `cast()` call was masking the type error without converting the object.

## Root cause

`tilecloud_chain/store/url.py:68`: `cast("dict[str, Any]", self._hosts_limit)` — the cast only suppresses the type checker but does not transform the object at runtime. The schema validator then receives a `_DatedConfig` instance and rejects it because it is not a dict.