### PR TITLE
Simplify get_host_name and remove duplicate header parsing

### DIFF
--- a/tilecloud_chain/main.py
+++ b/tilecloud_chain/main.py
@@ -194,7 +194,7 @@ app.add_middleware(
     },
 )
 
-proxy_headers_settings = getattr(config.settings, "proxy_headers", None)
+proxy_headers_settings = config.settings.proxy_headers
 if proxy_headers_settings is not None and proxy_headers_settings.type != "none":
     app.add_middleware(
         headers.ForwardedHeadersMiddleware,

--- a/tilecloud_chain/server.py
+++ b/tilecloud_chain/server.py
@@ -840,30 +840,7 @@ async def startup(_main_app: FastAPI) -> None:
 
 async def get_host_name(request: Request) -> str:
     """Get the host name from the request."""
-    # Get the Host header
-    host = request.headers.get("Host")
-
-    # Get the X-Forwarded-Host header
-    x_forwarded_host = request.headers.get("X-Forwarded-Host")
-
-    # Get the Forwarded header
-    forwarded = request.headers.get("Forwarded")
-
-    # Determine the host name
-    host_name: str | None = None
-    if forwarded:
-        # Parse the Forwarded header to get the host
-        # The Forwarded header can have multiple pieces of information
-        # Example: Forwarded: host=example.com;proto=https
-        forwarded_parts = forwarded.split(";")
-        for part in forwarded_parts:
-            if part.strip().startswith("host="):
-                host_name = part.strip().split("=")[1]
-                break
-    elif x_forwarded_host:
-        host_name = x_forwarded_host.split(",")[0]  # In case of multiple values
-    else:
-        host_name = host
+    host_name = request.headers.get("Host") or request.url.hostname
 
     if not host_name:
         raise HTTPException(status_code=400, detail="Host name not found in request headers")


### PR DESCRIPTION
Simplify `get_host_name` in `server.py` to use `request.headers.get(\"Host\")` directly instead of re-parsing `Forwarded` and `X-Forwarded-Host` headers — the `ForwardedHeadersMiddleware` from `c2casgiutils` already handles this.

Also replace `getattr` with direct attribute access for `proxy_headers_settings` in `main.py`.