### PR TITLE
Close all cached tile stores on application shutdown

### DIFF
--- a/tilecloud_chain/main.py
+++ b/tilecloud_chain/main.py
@@ -84,6 +84,9 @@ async def _lifespan(main_app: FastAPI) -> AsyncGenerator[None, None]:
 
     yield
 
+    _LOGGER.info("Shutting down the application")
+    await server.close()
+
 
 # Core Application Instance
 app = FastAPI(title="TileCloud-chain WMTS API", lifespan=_lifespan)

--- a/tilecloud_chain/multitilestore.py
+++ b/tilecloud_chain/multitilestore.py
@@ -128,6 +128,13 @@ class MultiTileStore(AsyncTileStore):
         keys = {f"{config_file}:{layer}:{grid}" for config_file, layer, grid in self.stores}
         return f"{self.__class__.__name__}({', '.join(stores)} - {', '.join(keys)})"
 
+    async def close(self) -> None:
+        """Close all cached tile stores."""
+        for dated_store in self.stores.values():
+            if dated_store is not None:
+                await dated_store.store.close()
+        self.stores.clear()
+
     @staticmethod
     def _get_layer(tile: Tile | None) -> tuple[str, str]:
         assert tile is not None

--- a/tilecloud_chain/server.py
+++ b/tilecloud_chain/server.py
@@ -233,6 +233,12 @@ class Server:
         self.s3_client_cache: dict[str, Any] = {}
         self.store_cache: dict[tuple[Path, str, str], DatedStore] = {}
 
+    async def close(self) -> None:
+        """Close all cached tile stores."""
+        for dated_store in self.store_cache.values():
+            await dated_store.store.close()
+        self.store_cache.clear()
+
     @staticmethod
     def get_expires_hours(config: tilecloud_chain.DatedConfig) -> float:
         """Get the expiration time in hours."""
@@ -836,6 +842,11 @@ async def startup(_main_app: FastAPI) -> None:
     """Initialize the FastAPI app."""
     config_file = settings.config_file
     await _init_tile_generation(config_file)
+
+
+async def close() -> None:
+    """Close the server resources."""
+    await server.close()
 
 
 async def get_host_name(request: Request) -> str:


### PR DESCRIPTION
The aiohttp ClientSession created in URLTileStore was not being closed on application shutdown because the cached stores in Server.store_cache and MultiTileStore.stores were never iterated to call close().

Changes:
- Add close() method to Server that closes all stores in store_cache
- Add close() method to MultiTileStore that closes all stores in stores dict
- Call Server.close() in the FastAPI lifespan shutdown handler