### PR TITLE
Close all remaining unclosed sessions and connectors on shutdown

### DIFF
--- a/tilecloud_chain/database_logger.py
+++ b/tilecloud_chain/database_logger.py
@@ -94,6 +94,12 @@ class DatabaseLoggerCommon:
         self.schema = schema
         self.table = table
 
+    async def close(self) -> None:
+        """Close the database connection."""
+        if self.connection is not None:
+            await self.connection.close()
+            self.connection = None
+
 
 class DatabaseLoggerInit(DatabaseLoggerCommon):
     """Log the generated tiles in a database."""

--- a/tilecloud_chain/generate.py
+++ b/tilecloud_chain/generate.py
@@ -82,6 +82,7 @@ class Generate:
         self._count_tiles_stored: CountSize | None = None
         self._queue_tilestore: AsyncTileStore | None = None
         self._cache_tilestore: AsyncTileStore | None = None
+        self._database_loggers: list[DatabaseLoggerCommon] = []
         self._options = options
         self._gene = gene
         self.out = out
@@ -126,6 +127,8 @@ class Generate:
 
         await self.generate_consume()
         await self.generate_resume(layer_name)
+        for database_logger in self._database_loggers:
+            await database_logger.close()
 
     async def _generate_init(self) -> None:
         if self._options.role != "server":
@@ -144,12 +147,12 @@ class Generate:
 
         main_config = await self._gene.get_main_config()
         if self._options.role in ("local", "master") and "logging" in main_config.config:
-            self._gene.imap(
-                DatabaseLoggerInit(
-                    main_config.config["logging"],
-                    self._options is not None and self._options.daemon,
-                ),
+            database_logger = DatabaseLoggerInit(
+                main_config.config["logging"],
+                self._options is not None and self._options.daemon,
             )
+            self._database_loggers.append(database_logger)
+            self._gene.imap(database_logger)
 
         if self._options.local_process_number is not None:
             await self.add_local_process_filter()
@@ -287,12 +290,12 @@ class Generate:
 
         main_config = await self._gene.get_main_config()
         if self._options.role in ("local", "slave") and "logging" in main_config.config:
-            self._gene.imap(
-                DatabaseLogger(
-                    main_config.config["logging"],
-                    self._options is not None and self._options.daemon,
-                ),
+            database_logger = DatabaseLogger(
+                main_config.config["logging"],
+                self._options is not None and self._options.daemon,
             )
+            self._database_loggers.append(database_logger)
+            self._gene.imap(database_logger)
             self._gene.init(
                 (self._queue_tilestore if "error_file" in main_config.config["generation"] else None),
                 self._options.daemon,
@@ -365,12 +368,12 @@ class Generate:
             self._gene.imap(delete_from_store)
 
         if self._options.role in ("local", "slave") and "logging" in main_config.config:
-            self._gene.imap(
-                DatabaseLogger(
-                    main_config.config["logging"],
-                    self._options is not None and self._options.daemon,
-                ),
+            database_logger = DatabaseLogger(
+                main_config.config["logging"],
+                self._options is not None and self._options.daemon,
             )
+            self._database_loggers.append(database_logger)
+            self._gene.imap(database_logger)
         self._gene.init(self._queue_tilestore, daemon=self._options.daemon)
 
     async def generate_consume(self) -> None:

--- a/tilecloud_chain/main.py
+++ b/tilecloud_chain/main.py
@@ -86,6 +86,7 @@ async def _lifespan(main_app: FastAPI) -> AsyncGenerator[None, None]:
 
     _LOGGER.info("Shutting down the application")
     await server.close()
+    await admin.close()
 
 
 # Core Application Instance

--- a/tilecloud_chain/server.py
+++ b/tilecloud_chain/server.py
@@ -234,10 +234,13 @@ class Server:
         self.store_cache: dict[tuple[Path, str, str], DatedStore] = {}
 
     async def close(self) -> None:
-        """Close all cached tile stores."""
+        """Close all cached tile stores and S3 clients."""
         for dated_store in self.store_cache.values():
             await dated_store.store.close()
         self.store_cache.clear()
+        for s3_client in self.s3_client_cache.values():
+            await s3_client.close()
+        self.s3_client_cache.clear()
 
     @staticmethod
     def get_expires_hours(config: tilecloud_chain.DatedConfig) -> float:
@@ -847,6 +850,8 @@ async def startup(_main_app: FastAPI) -> None:
 async def close() -> None:
     """Close the server resources."""
     await server.close()
+    if _TILEGENERATION is not None:
+        await _TILEGENERATION.close()
 
 
 async def get_host_name(request: Request) -> str:

--- a/tilecloud_chain/store/postgresql.py
+++ b/tilecloud_chain/store/postgresql.py
@@ -43,7 +43,7 @@ import sqlalchemy.sql.functions
 from anyio import Path
 from prometheus_client import Counter, Gauge, Summary
 from sqlalchemy import JSON, DateTime, Integer, Unicode, and_, delete, select, text, update
-from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker, create_async_engine
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 from tilecloud import Tile, TileCoord
 
@@ -201,126 +201,129 @@ async def _start_job(
     allowed_arguments: list[str],
 ) -> None:
     engine = create_async_engine(sqlalchemy_url)
-    SessionMaker = async_sessionmaker(engine)  # noqa
+    try:
+        SessionMaker = async_sessionmaker(engine)  # noqa
 
-    async with SessionMaker() as session:
-        result = await session.execute(select(Job).where(Job.id == job_id))
-        job = result.scalar()
-    assert job is not None
-
-    command = shlex.split(job.command)
-    command0 = command[0].replace("_", "-")
-
-    if command0 not in allowed_commands:
         async with SessionMaker() as session:
             result = await session.execute(select(Job).where(Job.id == job_id))
             job = result.scalar()
-            assert job is not None
-            job.status = _STATUS_ERROR
-            job.message = (
-                f"The given command '{command0}' is not allowed, allowed command are: "
-                f"{', '.join(allowed_commands)}"
-            )
-            await session.commit()
-        return
+        assert job is not None
 
-    add_role = False
-    arguments = {c.split("=")[0]: c.split("=")[1:] for c in command[1:]}
-    if command0 == "generate-tiles":
-        add_role = "--get-hash" not in arguments and "--get-bbox" not in arguments
+        command = shlex.split(job.command)
+        command0 = command[0].replace("_", "-")
 
-    for arg in arguments:
-        if arg.startswith("-") and arg not in allowed_arguments:
+        if command0 not in allowed_commands:
             async with SessionMaker() as session:
                 result = await session.execute(select(Job).where(Job.id == job_id))
                 job = result.scalar()
                 assert job is not None
                 job.status = _STATUS_ERROR
-                job.message = f"The argument {arg} is not allowed, allowed arguments are: {', '.join(allowed_arguments)}"
+                job.message = (
+                    f"The given command '{command0}' is not allowed, allowed command are: "
+                    f"{', '.join(allowed_commands)}"
+                )
                 await session.commit()
             return
 
-    final_command = [
-        command0,
-        f"--config={job.config_filename}",
-    ]
-    if add_role:
-        final_command += ["--role=master", "--quiet", f"--job-id={job.id}"]
-    final_command += command[1:]
+        add_role = False
+        arguments = {c.split("=")[0]: c.split("=")[1:] for c in command[1:]}
+        if command0 == "generate-tiles":
+            add_role = "--get-hash" not in arguments and "--get-bbox" not in arguments
 
-    display_command = shlex.join(final_command)
-    env: dict[str, str] = {**os.environ, "FRONTEND": "noninteractive"}
+        for arg in arguments:
+            if arg.startswith("-") and arg not in allowed_arguments:
+                async with SessionMaker() as session:
+                    result = await session.execute(select(Job).where(Job.id == job_id))
+                    job = result.scalar()
+                    assert job is not None
+                    job.status = _STATUS_ERROR
+                    job.message = f"The argument {arg} is not allowed, allowed arguments are: {', '.join(allowed_arguments)}"
+                    await session.commit()
+                return
 
-    main = None
-    if final_command[0] in ["generate-tiles", "generate_tiles"]:
-        main = generate.async_main
-    elif final_command[0] in ["generate-controller", "generate_controller"]:
-        main = controller.async_main
-    if main is not None:
-        # Delete potentially already existing queue entries
-        async with SessionMaker() as session:
-            await session.execute(delete(Queue).where(Queue.job_id == job_id))
-            await session.commit()
+        final_command = [
+            command0,
+            f"--config={job.config_filename}",
+        ]
+        if add_role:
+            final_command += ["--role=master", "--quiet", f"--job-id={job.id}"]
+        final_command += command[1:]
 
         display_command = shlex.join(final_command)
-        error = False
-        out = io.StringIO()
-        try:
-            _LOGGER.info("Running the command `%s` using the function directly", display_command)
-            await main(final_command, out)
-            _LOGGER.info("Successfully ran the command `%s` using the function directly", display_command)
-        except SystemExit as exception:
-            if exception.code is not None and exception.code != 0:
+        env: dict[str, str] = {**os.environ, "FRONTEND": "noninteractive"}
+
+        main = None
+        if final_command[0] in ["generate-tiles", "generate_tiles"]:
+            main = generate.async_main
+        elif final_command[0] in ["generate-controller", "generate_controller"]:
+            main = controller.async_main
+        if main is not None:
+            # Delete potentially already existing queue entries
+            async with SessionMaker() as session:
+                await session.execute(delete(Queue).where(Queue.job_id == job_id))
+                await session.commit()
+
+            display_command = shlex.join(final_command)
+            error = False
+            out = io.StringIO()
+            try:
+                _LOGGER.info("Running the command `%s` using the function directly", display_command)
+                await main(final_command, out)
+                _LOGGER.info("Successfully ran the command `%s` using the function directly", display_command)
+            except SystemExit as exception:
+                if exception.code is not None and exception.code != 0:
+                    _LOGGER.exception("Error while running the command `%s`", display_command)
+                    error = True
+            except Exception:  # pylint: disable=broad-exception-caught
                 _LOGGER.exception("Error while running the command `%s`", display_command)
                 error = True
-        except Exception:  # pylint: disable=broad-exception-caught
-            _LOGGER.exception("Error while running the command `%s`", display_command)
-            error = True
+
+            async with SessionMaker() as session:
+                result = await session.execute(select(Job).where(Job.id == job_id).with_for_update(of=Job))
+                job = result.scalar()
+                if job is not None:
+                    count_result = await session.scalar(
+                        select(sqlalchemy.sql.functions.count(Queue.id)).where(Queue.job_id == job_id),
+                    )
+                    assert count_result is not None
+                    job.meta_tiles_total = count_result
+                    job.status = _STATUS_ERROR if error else _STATUS_STARTED
+                    job.message = out.getvalue()[: settings.max_output_length]
+                    if error:
+                        job.tiles_started_at = None
+                await session.commit()
+            return
+
+        _LOGGER.info("Run the command `%s`", display_command)
+
+        completed_process = await asyncio.create_subprocess_exec(
+            *final_command,
+            env=env,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        stdout, stderr = await completed_process.communicate()
 
         async with SessionMaker() as session:
             result = await session.execute(select(Job).where(Job.id == job_id).with_for_update(of=Job))
             job = result.scalar()
-            if job is not None:
-                count_result = await session.scalar(
-                    select(sqlalchemy.sql.functions.count(Queue.id)).where(Queue.job_id == job_id),
-                )
-                assert count_result is not None
-                job.meta_tiles_total = count_result
-                job.status = _STATUS_ERROR if error else _STATUS_STARTED
-                job.message = out.getvalue()[: settings.max_output_length]
-                if error:
-                    job.tiles_started_at = None
+            assert job is not None
+            job.status = _STATUS_DONE if completed_process.returncode == 0 else _STATUS_ERROR
+            job.message = stdout.decode()
+            if stderr:
+                job.message += "\nError:\n" + stderr.decode()
             await session.commit()
-        return
 
-    _LOGGER.info("Run the command `%s`", display_command)
-
-    completed_process = await asyncio.create_subprocess_exec(
-        *final_command,
-        env=env,
-        stdout=asyncio.subprocess.PIPE,
-        stderr=asyncio.subprocess.PIPE,
-    )
-    stdout, stderr = await completed_process.communicate()
-
-    async with SessionMaker() as session:
-        result = await session.execute(select(Job).where(Job.id == job_id).with_for_update(of=Job))
-        job = result.scalar()
-        assert job is not None
-        job.status = _STATUS_DONE if completed_process.returncode == 0 else _STATUS_ERROR
-        job.message = stdout.decode()
-        if stderr:
-            job.message += "\nError:\n" + stderr.decode()
-        await session.commit()
-
-    if completed_process.returncode != 0:
-        _LOGGER.warning(
-            "The command `%s` exited with an error code: %s\nstdout:\n%s\nstderr:\n%s",
-            display_command,
-            completed_process.returncode,
-            stdout.decode(),
-            stderr.decode(),
-        )
+        if completed_process.returncode != 0:
+            _LOGGER.warning(
+                "The command `%s` exited with an error code: %s\nstdout:\n%s\nstderr:\n%s",
+                display_command,
+                completed_process.returncode,
+                stdout.decode(),
+                stderr.decode(),
+            )
+    finally:
+        await engine.dispose()
 
 
 class PostgresqlTileStore(AsyncTileStore):
@@ -346,6 +349,7 @@ class PostgresqlTileStore(AsyncTileStore):
         self._insert_lock = asyncio.Lock()
         self._flush_lock = asyncio.Lock()
         self.SessionMaker: async_sessionmaker[AsyncSession] | None = None  # pylint: disable=invalid-name
+        self._engine: AsyncEngine | None = None
 
     async def _flush_put_buffer(self, session: AsyncSession | None = None) -> None:
         async with self._flush_lock:
@@ -376,9 +380,9 @@ class PostgresqlTileStore(AsyncTileStore):
 
     async def init(self) -> None:
         """Initialize the store."""
-        engine = create_async_engine(self.sqlalchemy_url)
+        self._engine = create_async_engine(self.sqlalchemy_url)
 
-        async with engine.connect() as connection:
+        async with self._engine.connect() as connection:
             await connection.execute(sqlalchemy.schema.CreateSchema(_schema, if_not_exists=True))
             await connection.run_sync(Base.metadata.create_all)
             await connection.execute(
@@ -394,7 +398,7 @@ class PostgresqlTileStore(AsyncTileStore):
             )
             await connection.commit()
 
-        self.SessionMaker = async_sessionmaker(engine)  # pylint: disable=invalid-name
+        self.SessionMaker = async_sessionmaker(self._engine)  # pylint: disable=invalid-name
 
     async def create_job(
         self,
@@ -799,8 +803,10 @@ class PostgresqlTileStore(AsyncTileStore):
         return tile
 
     async def close(self) -> None:
-        """Flush pending queue inserts."""
+        """Flush pending queue inserts and close the engine."""
         await self._flush_put_buffer()
+        if self._engine is not None:
+            await self._engine.dispose()
 
     async def delete_one(self, tile: Tile) -> Tile:
         """Delete the meta tile from the queue."""

--- a/tilecloud_chain/views/admin.py
+++ b/tilecloud_chain/views/admin.py
@@ -80,6 +80,14 @@ async def startup(_main_app: FastAPI) -> None:
         _postgresql_store = await tilecloud_chain.store.postgresql.get_postgresql_queue_store(main_config)
 
 
+async def close() -> None:
+    """Close the admin resources."""
+    global _postgresql_store  # noqa: PLW0603
+    if _postgresql_store is not None:
+        await _postgresql_store.close()
+        _postgresql_store = None
+
+
 async def _get_postgresql_store() -> tilecloud_chain.store.postgresql.PostgresqlTileStore:
     """Get the PostgreSQL store."""
     if not _postgresql_store:


### PR DESCRIPTION
## Description

Fix the 'Unclosed connector' Sentry issue (MUTUALIZE-2MY) by ensuring all sessions, connections, and connectors are properly closed on application shutdown.

## Changes

### store/postgresql.py
- Store engine as instance attribute and dispose it in `close()`
- Wrap `_start_job()` in try/finally to always dispose the engine

### database_logger.py
- Add `close()` method to close the psycopg AsyncConnection

### generate.py
- Store DatabaseLogger instances and close them after generation completes

### server.py
- Close aiobotocore S3 clients in `Server.close()`
- Close `_TILEGENERATION` global in module-level `close()`

### views/admin.py
- Add `close()` function to close the global `_postgresql_store`

### main.py
- Call `admin.close()` in the FastAPI lifespan shutdown handler