### PR TITLE
Handle aiohttp SSL shutdown timeout errors during Azure client close

### DIFF
--- a/tilecloud_chain/multitilestore.py
+++ b/tilecloud_chain/multitilestore.py
@@ -132,7 +132,10 @@ class MultiTileStore(AsyncTileStore):
         """Close all cached tile stores."""
         for dated_store in self.stores.values():
             if dated_store is not None:
-                await dated_store.store.close()
+                try:
+                    await dated_store.store.close()
+                except Exception:  # noqa: BLE001
+                    logger.warning("Error while closing tile store", exc_info=True)
         self.stores.clear()
 
     @staticmethod

--- a/tilecloud_chain/server.py
+++ b/tilecloud_chain/server.py
@@ -235,11 +235,17 @@ class Server:
 
     async def close(self) -> None:
         """Close all cached tile stores and S3 clients."""
-        for dated_store in self.store_cache.values():
-            await dated_store.store.close()
+        for dated_store in list(self.store_cache.values()):
+            try:
+                await dated_store.store.close()
+            except Exception:  # noqa: BLE001
+                _LOGGER.warning("Error while closing tile store", exc_info=True)
         self.store_cache.clear()
         for s3_client in self.s3_client_cache.values():
-            await s3_client.close()
+            try:
+                await s3_client.close()
+            except Exception:  # noqa: BLE001
+                _LOGGER.warning("Error while closing S3 client", exc_info=True)
         self.s3_client_cache.clear()
 
     @staticmethod

--- a/tilecloud_chain/store/azure_storage_blob.py
+++ b/tilecloud_chain/store/azure_storage_blob.py
@@ -1,6 +1,7 @@
 import logging
 from collections.abc import AsyncIterator
 
+import aiohttp
 from azure.identity import DefaultAzureCredential
 from azure.storage.blob import ContentSettings
 from azure.storage.blob.aio import BlobServiceClient, ContainerClient
@@ -55,11 +56,18 @@ class AzureStorageBlobTileStore(AsyncTileStore):
         self.dry_run = dry_run
         self.cache_control = cache_control
 
+    async def _close_client(self, client: ContainerClient | BlobServiceClient) -> None:
+        """Close an Azure client, catching and logging SSL shutdown errors."""
+        try:
+            await client.close()
+        except (TimeoutError, aiohttp.ClientConnectionError):
+            _LOGGER.warning("Ignored error during Azure client close", exc_info=True)
+
     async def close(self) -> None:
         """Close the Azure container client session."""
-        await self.container_client.close()
+        await self._close_client(self.container_client)
         if self._blob_service_client is not None:
-            await self._blob_service_client.close()
+            await self._close_client(self._blob_service_client)
 
     async def __contains__(self, tile: Tile) -> bool:
         """Return true if this store contains ``tile``."""


### PR DESCRIPTION
## Description

Fix the two Sentry errors that keep recurring despite previous fixes:

- https://camptocamp.sentry.io/issues/7592141662/ (MUTUALIZE-2MY - Unclosed connector)
- https://camptocamp.sentry.io/issues/7592142282/ (MUTUALIZE-2N0 - ClientConnectionError: SSL shutdown timed out)

### Root cause

The Azure SDK's `ContainerClient` and `BlobServiceClient` use `aiohttp` internally for HTTP transport. When `close()` is called on an Azure client, the SDK attempts SSL shutdown on all open connections. If a connection does not respond in time, a `TimeoutError` is raised. This exception was not caught, which:

1. Prevented proper cleanup of the aiohttp `ClientSession` and `TCPConnector`, causing the "Unclosed connector" warning
2. Created unhandled future exceptions ("Future exception was never retrieved") for the `ClientConnectionError`

### Changes

- **`AzureStorageBlobTileStore`**: catch `TimeoutError` and `aiohttp.ClientConnectionError` during `close()` to prevent unhandled exceptions and ensure the connector is properly cleaned up
- **`Server.close()`**: wrap individual store and S3 client close calls in try/except so one failure doesn't prevent closing remaining resources
- **`MultiTileStore.close()`**: same graceful error handling