### PR TITLE
Fix legend URL to always use current base_url and add debug logs for missing layers

### DIFF
--- a/tilecloud_chain/server.py
+++ b/tilecloud_chain/server.py
@@ -37,7 +37,7 @@ from copy import copy
 from dataclasses import dataclass
 from io import BytesIO
 from typing import Annotated, Any, Literal, NamedTuple, cast
-from urllib.parse import urlencode
+from urllib.parse import urlencode, urlparse
 
 import aiobotocore.session
 import aiohttp
@@ -1295,6 +1295,16 @@ async def _get(path: str, cache: tilecloud_chain.configuration.Cache) -> bytes |
         return await p.read_bytes()
 
 
+def _get_legend_href(base_url: str, path: str) -> str:
+    parsed = urlparse(path)
+    if parsed.scheme or parsed.netloc:
+        path = parsed.path.lstrip("/")
+        base_path = urlparse(base_url).path.lstrip("/")
+        if path.startswith(base_path):
+            path = path.removeprefix(base_path)
+    return base_url + path
+
+
 async def _get_layer_legend(
     layer_name: str,
     layer: configuration.Layer,
@@ -1350,7 +1360,7 @@ async def _get_layer_legend(
         return [
             configuration.LayerLegendItem(
                 mime_type=legend_mime,
-                href=base_url + legend_metadata["path"],
+                href=_get_legend_href(base_url, legend_metadata["path"]),
                 min_resolution=legend_metadata.get("min_resolution"),
                 max_resolution=legend_metadata.get("max_resolution"),
                 width=legend_metadata["width"],

--- a/tilecloud_chain/templates/openlayers.html
+++ b/tilecloud_chain/templates/openlayers.html
@@ -547,10 +547,20 @@
             if (!gridId) {
               return null;
             }
-            const options = ol.source.WMTS.optionsFromCapabilities(result, {
-              layer: wmtsLayer.Identifier,
-              matrixSet: gridId,
-            });
+            const options = (function () {
+              try {
+                return ol.source.WMTS.optionsFromCapabilities(result, {
+                  layer: wmtsLayer.Identifier,
+                  matrixSet: gridId,
+                });
+              } catch (error) {
+                console.error(
+                  'Error in optionsFromCapabilities for layer "%s" matrixSet "%s":',
+                  wmtsLayer.Identifier, gridId, error
+                );
+                return null;
+              }
+            })();
             if (!options || !options.tileGrid) {
               return null;
             }
@@ -575,9 +585,19 @@
           return definitions;
         }
 
-        const fallbackOptions = ol.source.WMTS.optionsFromCapabilities(result, {
-          layer: wmtsLayer.Identifier,
-        });
+        const fallbackOptions = (function () {
+            try {
+              return ol.source.WMTS.optionsFromCapabilities(result, {
+                layer: wmtsLayer.Identifier,
+              });
+            } catch (error) {
+              console.error(
+                'Error in fallback optionsFromCapabilities for layer "%s":',
+                wmtsLayer.Identifier, error
+              );
+              return null;
+            }
+          })();
         if (!fallbackOptions || !fallbackOptions.tileGrid) {
           return [];
         }
@@ -610,6 +630,11 @@
           for (const wmtsLayer of result.Contents.Layer) {
             const gridDefinitions = getLayerGridDefinitions(result, wmtsLayer);
             if (gridDefinitions.length === 0) {
+              console.warn(
+                'Skipping layer "%s" (%s): no grid definitions found',
+                wmtsLayer.Identifier,
+                wmtsLayer.Title || wmtsLayer.Identifier
+              );
               continue;
             }
             const selectedGridId =

--- a/tilecloud_chain/tests/test_controller.py
+++ b/tilecloud_chain/tests/test_controller.py
@@ -2631,3 +2631,57 @@ sqs:
 </Capabilities>""",
             True,
         )
+
+    @pytest.mark.asyncio
+    async def test_legend_absolute_path(self) -> None:
+        """Test that LegendURL uses base_url even when legend.yaml stores an absolute path."""
+        await self.assert_tiles_generated(
+            cmd=".build/venv/bin/generate-controler -c tilegeneration/test-legends.yaml --legends",
+            main_func=controller.async_main,
+            directory="/tmp/tiles/1.0.0/",
+            tiles_pattern="%s/default/%s",
+            tiles=[
+                ("point", "legend-5.png"),
+                ("point", "legend.yaml"),
+                ("line", "legend-5.png"),
+                ("line", "legend-50.png"),
+                ("line", "legend.yaml"),
+                ("polygon", "legend-5.png"),
+                ("polygon", "legend.yaml"),
+                ("all", "legend-5.png"),
+                ("all", "legend-50.png"),
+                ("all", "legend.yaml"),
+            ],
+        )
+
+        # Overwrite legend.yaml with an absolute path
+        legend_yaml_path = Path("/tmp/tiles/1.0.0/point/default/legend.yaml")
+        with legend_yaml_path.open("w", encoding="utf-8") as f:
+            yaml.dump(
+                {
+                    "metadata": [
+                        {
+                            "height": 20,
+                            "mime_type": "image/png",
+                            "path": "https://old-host.camptocamp.com/tiles/static/1.0.0/point/default/legend-5.png",
+                            "width": 64,
+                        },
+                    ],
+                },
+                f,
+                Dumper=yaml.SafeDumper,
+            )
+
+        gene = TileGeneration(AnyioPath("tilegeneration/test-legends.yaml"), configure_logging=False)
+        await gene.ainit()
+        config = await gene.get_config(AnyioPath("tilegeneration/test-legends.yaml"))
+
+        # Clear the legend config cache to force re-reading the modified file
+        server._LEGEND_CONFIG_CACHE.clear()
+
+        capabilities = await wmts_capabilities(gene, config.config["generation"]["default_cache"])
+
+        # The LegendURL must use the current base_url (http://wmts1/), not the absolute path
+        assert ('xlink:href="http://wmts1/tiles/static/1.0.0/point/default/legend-5.png') in capabilities, (
+            f"LegendURL should use the current base_url, got:\n{capabilities}"
+        )


### PR DESCRIPTION
## Problems

1. **LegendURL with wrong host**: If the `legend.yaml` file stored in the cache contains an absolute path (e.g. with an old host), the generated `LegendURL` uses that old host instead of the currently configured `base_url`.

2. **`osm` layer missing from the list on `/admin/test`**: No logs explain why a valid WMTS layer does not appear in the layer list of the test page.

## Changes

### `tilecloud_chain/server.py`
- New `_get_legend_href()` function that extracts the relative path if `legend.yaml` contains an absolute path, ensuring only the current `base_url` from the cache config is used for the host

### `tilecloud_chain/templates/openlayers.html`
- `try-catch` around `ol.source.WMTS.optionsFromCapabilities()` (main and fallback calls) with `console.error()`
- `console.warn()` when a layer is skipped due to missing `gridDefinitions`

### `tilecloud_chain/tests/test_controller.py`
- New `test_legend_absolute_path` test: writes a `legend.yaml` with an absolute `path`, verifies that the `LegendURL` uses the current `base_url`