### PR TITLE
Rewrite README with comprehensive feature documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # TileCloud-chain
 
-TileCloud Chain is a comprehensive toolset for managing tile generation workflows. It supports various source and destination formats, making it a versatile solution for map tile management.
+TileCloud Chain is a comprehensive toolset for generating, serving, and managing map tiles. It supports WMS and Mapnik sources, multiple cloud and local storage backends, distributed master/slave generation with configurable queue backends, and a built-in WMTS tile server with an administrative web interface.
 
 ## Sources
 
 - Web Map Service (WMS)
-- Mapnik rendering engine
+- Mapnik rendering engine (legacy)
 
 ## Destination Formats and Storage
 
@@ -13,27 +13,43 @@ TileCloud Chain is a comprehensive toolset for managing tile generation workflow
 - Amazon S3 storage
 - Azure Blob storage
 - Local filesystem
+- SQLite (MBTiles) support (legacy)
+- Berkeley DB integration (legacy)
 
 ## Key Features
 
-- Tile generation with configurable parameters
-- Automatic removal of empty tiles
-- Geographic filtering (bbox and geometry-based)
-- MetaTile support for efficient generation
-- Legend image generation
-- GetCapabilities document
-- OpenLayers demo page
-- Empty tile detection via hashing
-- Cache synchronization
-- Post-processing capabilities
+- **Tile generation** in three modes: `local` (single machine), `master` (prepares jobs for a queue), `slave` (consumes jobs from the queue)
+- **Distributed generation** with configurable queue backends: Redis, Amazon SQS, or PostgreSQL
+- **Daemon mode** for continuous slave operation
+- **Zoom separation** via `min_resolution_seed`: pre-generate low zooms, serve high zooms dynamically through the internal MapCache
+- **Geometry-based filtering** using PostGIS SQL queries or GDAL datasources (e.g. Shapefile) — only generate tiles that intersect your areas of interest
+- **Bounding box filtering** to restrict tile generation to a geographic extent
+- **Multi-grid support**: multiple grids per layer with TileMatrixSetLimits in WMTS capabilities
+- **Layer dimensions**: multi-variant tilesets (e.g. time, date) with WMTS dimension support
+- **MetaTiles**: efficient generation by fetching multiple tiles in a single WMS request, with configurable size and border buffer
+- **Empty tile detection** via SHA-1 hashing at both metatile and tile level
+- **Tile post-processing**: run external tools (optipng, jpegoptim, pngquant) and configure Pillow save options
+- **Legend image generation**: per-layer, per-zoom legend images with SHA-1 deduplication
+- **WMTS GetCapabilities**: automatic XML generation with TileMatrixSetLimits, legend URLs, and ResourceURLs for GetFeatureInfo
+- **GetFeatureInfo** (interrogation): WMS feature info proxy, available via REST and KVP interfaces
+- **WMTS tile server**: built-in FastAPI server serving tiles via RESTful URLs and KVP interface, with caching, CORS, CSP, GZip compression, and configurable cache expiration
+- **Internal MapCache**: Redis-based dynamic tile cache with locking for concurrent generation, WMS fallback for cache misses, and geometry-based redirect
+- **Administration web interface**: job status monitoring, PostgreSQL job lifecycle (create/cancel/retry), command execution with ACL validation, OAuth2 GitHub authentication, and configuration validation
+- **OpenLayers demo page**: interactive map with WMTS layers, dimension selectors, GetFeatureInfo on click, and state persistence in the URL
+- **Multi-tenant mode**: host-based configuration resolution for serving multiple projects from a single deployment
+- **Monitoring**: Prometheus metrics (`tilecloud_chain_*` counters) and Sentry error reporting
+- **Empty tile detection** via hashing
+- **Geographic filtering** (bbox and geometry-based)
 
 ## Legacy Support
 
-Note: The following features are maintained for backward compatibility:
+The following features are maintained for backward compatibility:
 
+- Mapnik rendering
+- Mapnik UTFGrid (interactive tile grids)
 - Berkeley DB integration
 - SQLite (MBTiles) support
-- Mapnik rendering
+- Error file generation and tile retry (`--tiles`)
 
 ## Visual Preview
 
@@ -45,35 +61,20 @@ The test page:
 
 ![TileCloud-chain test interface](./test-screenshot.png)
 
+[Demo](https://geomapfish-demo-master.camptocamp.com/tiles/admin/test).
+
 ## Getting Started
 
 Create a configuration file at `tilegeneration/config.yaml`.
 
 Reference the [example configuration](https://github.com/camptocamp/tilecloud-chain/blob/master/example/tilegeneration/config.yaml).
 
-## Support Policy
+## Commands
 
-Only the latest release receives active support. Versions prior to 1.11 contain security vulnerabilities and should not be used.
-
-## Development
-
-### Building
-
-```bash
-make build
-```
-
-### Quality Assurance
-
-```bash
-make prospector
-```
-
-### Testing
-
-```bash
-make tests
-```
+| Command               | Description                                                                                                                                |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| `generate-tiles`      | Generate tiles from WMS or Mapnik sources. Supports `local`, `master`, and `slave` roles, and `--get-hash` for computing empty tile hashes |
+| `generate-controller` | Generate WMTS capabilities, legend images, display queue status, or dump the effective configuration                                       |
 
 ## Generation Pipeline
 
@@ -112,6 +113,54 @@ flowchart TD
     I -->|local| O1["Store tiles to cache (S3, local, etc.)"]
     I -->|slave| O2["Store tiles to cache and delete processed queue items"]
     I -->|hash| O4["Console output only"]
+```
+
+## Server
+
+TileCloud Chain includes a built-in WMTS tile server powered by FastAPI:
+
+- **WMTS REST API**: tile serving with and without dimensions
+- **KVP interface**: supports GetCapabilities, GetTile, and GetFeatureInfo via query parameters
+- **Internal MapCache**: Redis-based dynamic tile cache with locking for concurrent generation and WMS fallback on cache miss
+- **GetFeatureInfo**: proxies feature info requests to the configured WMS backend
+- **Cache headers**: configurable `Expires` and `Cache-Control`
+- **CORS**: configurable origins, methods, headers, and credentials
+- **CSP**: Content Security Policy with nonce-based scripts
+- **Prometheus metrics**: request counters and resource usage
+- **Sentry**: error reporting integration
+- **Multi-tenant**: host-based configuration resolution
+- **Tile-Backend header**: reports whether a tile came from cache, Redis, or WMS generation
+
+## Admin Interface
+
+The web admin interface provides:
+
+- **Job status**: per-job counters (to generate, pending, error) with PostgreSQL, or queue counters with Redis/SQS
+- **PostgreSQL job management**: create, cancel, and retry jobs (retry only errored metatiles)
+- **Command execution**: run `generate-tiles` and `generate-controller` with validated arguments
+- **Configuration validation**: schema validation errors and deprecation warnings
+- **Predefined commands**: quick-run buttons for common operations
+- **OAuth2 authentication**: GitHub OAuth2 with configurable access control
+- **Test page**: OpenLayers map with WMTS layers, dimension selectors, GetFeatureInfo, and URL-based state persistence
+
+## Development
+
+### Building
+
+```bash
+make build
+```
+
+### Quality Assurance
+
+```bash
+make prospector
+```
+
+### Testing
+
+```bash
+make tests
 ```
 
 ## Documentation


### PR DESCRIPTION
**Summary**
Rewrite the README to properly document all TileCloud-chain features.

**Context**
The README was missing many key features: zoom separation, multi-grid, dimensions, GetFeatureInfo, distributed queues, master/slave generation, the built-in WMTS server, the admin interface, multi-tenant mode, and monitoring (Prometheus, Sentry).

**Implementation Details**
- Add zoom separation (`min_resolution_seed`), multi-grid, dimensions, GetFeatureInfo
- Add queues (Redis, SQS, PostgreSQL) and master/slave distribution
- Add a Server section covering WMTS REST/KVP, MapCache, CORS, CSP, Prometheus, Sentry, multi-tenant
- Add an Admin Interface section with job management, OAuth2, command execution, test page
- Add a Commands reference table (generate-tiles, generate-controller)
- Move Mapnik, Mapnik UTFGrid, MBTiles, Berkeley DB, error file to Legacy Support
- Exclude cost, copy, process, expire-tiles from the README