### PR TITLE
Return 404 instead of 500 when no configuration file exists for the host

### DIFF
--- a/tilecloud_chain/__init__.py
+++ b/tilecloud_chain/__init__.py
@@ -393,6 +393,9 @@ class DatedConfig:
         self.mtime = mtime
         self.file = file
 
+    def __bool__(self) -> bool:
+        return bool(self.config)
+
 
 class DatedGeoms:
     """Geoms with timestamps to be able to invalidate it on configuration change."""
@@ -1052,7 +1055,7 @@ class TileGeneration:
         assert host
         hosts = await self.get_hosts()
         if host not in hosts:
-            _LOGGER.error("Missing host '%s' in global config", host)
+            _LOGGER.warning("No configuration found for host '%s' in global hosts config", host)
             return None
         default_config_file = settings.config_file or Path("tilegeneration/config.yaml")
         config_file = hosts.get(
@@ -1066,7 +1069,7 @@ class TileGeneration:
         """Get the configuration for the given host."""
         config_file = await self.get_host_config_file(host)
         if not config_file:
-            _LOGGER.error("No config file for host %s", host)
+            _LOGGER.warning("No configuration file found for host '%s'", host)
         else:
             _LOGGER.debug("For the host %s, use config file: %s", host, config_file)
         return (

--- a/tilecloud_chain/views/admin.py
+++ b/tilecloud_chain/views/admin.py
@@ -431,6 +431,8 @@ async def admin_test(
     """Test the admin view."""
     host = request.headers.get("host", "localhost")
     config = await gene.get_host_config(host)
+    if not config:
+        raise HTTPException(status_code=404, detail=f"No configuration found for host '{host}'")
     srs = config.config["openlayers"].get("srs", configuration.SRS_DEFAULT)
     proj4js_def = config.config["openlayers"].get("proj4js_def")
     if proj4js_def is None:


### PR DESCRIPTION
**Summary**

Return a proper 404 HTTP error with a clear message when a request is made for a host that has no corresponding configuration file, instead of crashing with a 500 error.

**Changes**

- Add `__bool__` method to `DatedConfig` so that `if not config:` guards in `server.py` work correctly (empty config is now falsy)
- Add a 404 guard in `admin_test` to catch missing host config before accessing `config.config["openlayers"]`
- Downgrade related log messages from `ERROR` to `WARNING` with more descriptive messages

<!-- pull request links -->
See JIRA issue: [HOST-404](https://camptocamp.atlassian.net/browse/HOST-404).