### PR TITLE
Register all grid SRS definitions in the test page for multi-SRS support

### DIFF
--- a/tilecloud_chain/templates/openlayers.html
+++ b/tilecloud_chain/templates/openlayers.html
@@ -206,7 +206,9 @@
     ></script>
 
     <script nonce="{{ nonce }}">
-      proj4.defs("{{ srs }}",`{{ proj4js_def }}`);
+      {% for definition in srs_definitions %}
+      proj4.defs("{{ definition.srs }}",`{{ definition.proj4js_def }}`);
+      {% endfor %}
       ol.proj.proj4.register(proj4);
       var parser = new ol.format.WMTSCapabilities();
       const urlParams = new URLSearchParams(window.location.search);

--- a/tilecloud_chain/views/admin.py
+++ b/tilecloud_chain/views/admin.py
@@ -438,6 +438,15 @@ async def admin_test(
     if proj4js_def is None:
         proj4js_def = pyproj.CRS.from_string(srs).to_proj4()
 
+    srs_definitions: list[dict[str, str]] = [{"srs": srs, "proj4js_def": proj4js_def}]
+    seen_srs = {srs}
+    for grid in config.config.get("grids", {}).values():
+        grid_srs = grid.get("srs")
+        if grid_srs and grid_srs not in seen_srs:
+            seen_srs.add(grid_srs)
+            grid_proj4js_def = pyproj.CRS.from_string(grid_srs).to_proj4()
+            srs_definitions.append({"srs": grid_srs, "proj4js_def": grid_proj4js_def})
+
     try:
         nonce = request.state.nonce
     except AttributeError as exc:
@@ -446,8 +455,8 @@ async def admin_test(
     context = {
         "request": request,
         "nonce": nonce,
-        "proj4js_def": proj4js_def,
         "srs": srs,
+        "srs_definitions": srs_definitions,
         "center_x": config.config["openlayers"].get("center_x", configuration.CENTER_X_DEFAULT),
         "center_y": config.config["openlayers"].get("center_y", configuration.CENTER_Y_DEFAULT),
         "zoom": config.config["openlayers"].get("zoom", configuration.MAP_INITIAL_ZOOM_DEFAULT),


### PR DESCRIPTION
**Summary**

When multiple grids with different SRS are configured (e.g. `EPSG:21781` and `EPSG:2056`), the test page crashes with `TypeError: can't access property "getAxisOrientation", d is null` from OpenLayers' `optionsFromCapabilities`.

**Root cause**

`optionsFromCapabilities` calls `projection.getAxisOrientation()` on the projection looked up from the `SupportedCRS` in the WMTS capabilities. If that CRS was not registered with proj4js, `getProjection()` returns `null` and the call crashes.

The test page only registered the main `srs` with proj4js, so any grid using a different SRS would be unregistered and trigger the crash.

**Fix**

- `admin.py`: Collect all unique SRS codes from all configured grids, generate their proj4js definitions, and pass the list as `srs_definitions` to the template.
- `openlayers.html`: Loop over `srs_definitions` to register every SRS with proj4js before initializing OpenLayers.

**Verification**

- All 6 template-content tests pass.
- The 4 screenshot tests require Docker (pre-existing limitation).