### PR TITLE
Filter object values instead of specific property names in feature info table

### DIFF
--- a/tilecloud_chain/templates/openlayers.html
+++ b/tilecloud_chain/templates/openlayers.html
@@ -1363,7 +1363,7 @@
 
                     html += '<table class="feature-info-table">';
                     Object.entries(props).forEach(function ([key, value]) {
-                      if (key === 'geometry' || key === 'layer' || key === 'layerName' || key === 'boundedBy') {
+                      if (typeof value === 'object' && value !== null) {
                         return;
                       }
                       var displayValue = value !== null && value !== undefined ? String(value) : '';


### PR DESCRIPTION
Replace the hardcoded list of property names to exclude (geometry, layer, layerName, boundedBy) with a generic check that skips any object value. This ensures `geom` and other object-typed properties are not shown in the feature info table since they are not meaningful as text display.