### PR TITLE
Downgrade PostgresqlTileStoreError logs from error to warning in admin endpoints

### DIFF
--- a/tilecloud_chain/views/admin.py
+++ b/tilecloud_chain/views/admin.py
@@ -369,7 +369,7 @@ async def admin_create_job(
         await postgresql_store.create_job(name, command, config_filename)
         return JobResponse(success=True)
     except tilecloud_chain.store.postgresql.PostgresqlTileStoreError as e:
-        _LOG.exception("Error while creating the job")
+        _LOG.warning("Error while creating the job", exc_info=True)
         raise HTTPException(status_code=400, detail=str(e))  # noqa: B904 # pylint: disable=raise-missing-from
 
 
@@ -394,7 +394,7 @@ async def admin_cancel_job(
         await postgresql_store.cancel(job_id, config_filename)
         return JobResponse(success=True)
     except tilecloud_chain.store.postgresql.PostgresqlTileStoreError as e:
-        _LOG.exception("Exception while cancelling the job")
+        _LOG.warning("Exception while cancelling the job", exc_info=True)
         raise HTTPException(status_code=400, detail=str(e))  # noqa: B904 # pylint: disable=raise-missing-from
 
 
@@ -419,7 +419,7 @@ async def admin_retry_job(
         await postgresql_store.retry(job_id, config_filename)
         return JobResponse(success=True)
     except tilecloud_chain.store.postgresql.PostgresqlTileStoreError as e:
-        _LOG.exception("Exception while retrying the job")
+        _LOG.warning("Exception while retrying the job", exc_info=True)
         raise HTTPException(status_code=400, detail=str(e))  # noqa: B904 # pylint: disable=raise-missing-from
 
 


### PR DESCRIPTION
**Summary**

Change `_LOG.exception` to `_LOG.warning(..., exc_info=True)` in the three admin endpoints (`create_job`, `cancel_job`, `retry_job`) to avoid sending expected client errors (HTTP 400) to Sentry as error-level events.

**Context**

- Fixes Sentry issue MUTUALIZE-2NN
- These are handled client errors (PostgresqlTileStoreError raised when the job is not found or has an incorrect status), not server errors. The user already receives a proper 400 response.

**Implementation Details**

- Replaced `_LOG.exception(...)` with `_LOG.warning(..., exc_info=True)` to keep the full traceback in local logs while downgrading the Sentry level to warning.

<!-- pull request links -->
See JIRA issue: [ERRORS-7621876792](https://camptocamp.atlassian.net/browse/ERRORS-7621876792).