### PR TITLE
Handle aiohttp ClientConnectionError during URLTileStore session close

### DIFF
--- a/tilecloud_chain/store/url.py
+++ b/tilecloud_chain/store/url.py
@@ -47,7 +47,10 @@ class URLTileStore(AsyncTileStore):
 
     async def close(self) -> None:
         """Close the aiohttp session."""
-        await self._session.close()
+        try:
+            await self._session.close()
+        except (TimeoutError, aiohttp.ClientConnectionError):
+            _LOGGER.warning("Ignored error during aiohttp session close", exc_info=True)
 
     async def _get_hosts_limit(self) -> host_limit.HostLimit:
         """Initialize the store."""

--- a/tilecloud_chain/tests/test_url_store.py
+++ b/tilecloud_chain/tests/test_url_store.py
@@ -1,0 +1,36 @@
+"""Tests for the URL tile store."""
+
+import logging
+from unittest.mock import patch
+
+import aiohttp
+import pytest
+
+from tilecloud_chain.store.url import URLTileStore
+
+
+class TestURLTileStore:
+    """Tests for the URLTileStore class."""
+
+    @pytest.mark.asyncio
+    async def test_close_handles_client_connection_error(self) -> None:
+        """Test that close() catches ClientConnectionError gracefully."""
+        store = URLTileStore([])
+        with patch.object(store._session, "close", side_effect=aiohttp.ClientConnectionError):
+            await store.close()
+
+    @pytest.mark.asyncio
+    async def test_close_handles_timeout_error(self) -> None:
+        """Test that close() catches TimeoutError gracefully."""
+        store = URLTileStore([])
+        with patch.object(store._session, "close", side_effect=TimeoutError):
+            await store.close()
+
+    @pytest.mark.asyncio
+    async def test_close_logs_warning_on_error(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Test that close() logs a warning on error."""
+        store = URLTileStore([])
+        caplog.set_level(logging.WARNING)
+        with patch.object(store._session, "close", side_effect=aiohttp.ClientConnectionError):
+            await store.close()
+        assert "Ignored error during aiohttp session close" in caplog.text


### PR DESCRIPTION
## Summary

Handle aiohttp `ClientConnectionError` and `TimeoutError` during `URLTileStore` session close to prevent Sentry errors.

## Context

Three Sentry issues (MUTUALIZE-2MZ, MUTUALIZE-2MY, MUTUALIZE-2N0) report unclosed client sessions, unclosed connectors, and SSL shutdown timeouts during tile serving.

## Implementation Details

- Added `try/except` in `URLTileStore.close()` to catch `TimeoutError` and `aiohttp.ClientConnectionError`, matching the pattern already used in `AzureStorageBlobTileStore._close_client()`.
- Added 3 test cases for the error handling.

## Impact/Risks

- Low risk: only changes error handling during session cleanup.
- No backward compatibility impact.