### PR TITLE
Filter reserved WMS params from user config, handle SRS/CRS for WMS 1.3.0

### DIFF
--- a/tilecloud_chain/__init__.py
+++ b/tilecloud_chain/__init__.py
@@ -94,6 +94,19 @@ _META_TILE_COORD_CONTEXT: contextvars.ContextVar[str | None] = contextvars.Conte
 
 _ALLOWED_COMMANDS = settings.allowed_process_commands
 
+WMS_RESERVED_PARAMS: set[str] = {
+    "LAYERS",
+    "FORMAT",
+    "TRANSPARENT",
+    "SERVICE",
+    "REQUEST",
+    "SRS",
+    "CRS",
+    "BBOX",
+    "WIDTH",
+    "HEIGHT",
+}
+
 
 def formatted_metadata(tile: Tile) -> str:
     """Get human readable string of the metadata."""

--- a/tilecloud_chain/generate.py
+++ b/tilecloud_chain/generate.py
@@ -25,6 +25,7 @@ from tilecloud.layout.wms import WMSTileLayout
 
 import tilecloud_chain
 from tilecloud_chain import (
+    WMS_RESERVED_PARAMS,
     Count,
     CountSize,
     HashDropper,
@@ -533,31 +534,40 @@ class TilestoreGetter:
         grid = tilecloud_chain.get_grid_config(config, layer_name, grid_name)
         if layer["type"] == "wms":
             params = layer.get("params", {}).copy()
+            reserved = params.keys() & WMS_RESERVED_PARAMS
+            if reserved:
+                _LOGGER.warning(
+                    "Reserved WMS parameters ignored in layer '%s' params: %s",
+                    layer_name,
+                    ", ".join(sorted(reserved)),
+                )
+                for key in reserved:
+                    del params[key]
             if "STYLES" not in params:
                 params["STYLES"] = ",".join(layer["wmts_style"] for _ in layer.get("layers", "").split(","))
             if layer.get("generate_salt", False):
                 params["SALT"] = str(random.randint(0, 999999))  # nosec # noqa: S311
 
+            srs = get_grid_config(config, layer_name, grid_name).get(
+                "srs",
+                configuration.SRS_DEFAULT,
+            )
             # Get the metatile image from the WMS server
-            url_tile_store = URLTileStore(
-                tile_layouts=(
-                    WMSTileLayout(
-                        url=layer["url"],
-                        layers=layer.get("layers", ""),
-                        srs=get_grid_config(config, layer_name, grid_name).get(
-                            "srs",
-                            configuration.SRS_DEFAULT,
-                        ),
-                        format_pattern=layer["mime_type"],
-                        border=(
-                            layer.get("meta_buffer", configuration.LAYER_META_BUFFER_DEFAULT)
-                            if layer["meta"]
-                            else 0
-                        ),
-                        tilegrid=self.gene._gene.get_grid(config, grid_name),  # noqa: SLF001
-                        params=params,
-                    ),
+            tile_layout = WMSTileLayout(
+                url=layer["url"],
+                layers=layer.get("layers", ""),
+                srs=srs,
+                format_pattern=layer["mime_type"],
+                border=(
+                    layer.get("meta_buffer", configuration.LAYER_META_BUFFER_DEFAULT) if layer["meta"] else 0
                 ),
+                tilegrid=self.gene._gene.get_grid(config, grid_name),  # noqa: SLF001
+                params=params,
+            )
+            if params.get("VERSION", "").startswith("1.3"):
+                tile_layout.params["CRS"] = tile_layout.params.pop("SRS")
+            url_tile_store = URLTileStore(
+                tile_layouts=(tile_layout,),
                 headers=layer["headers"],
             )
             return TimedTileStoreWrapper(url_tile_store, "wms")

--- a/tilecloud_chain/tests/test_admin.py
+++ b/tilecloud_chain/tests/test_admin.py
@@ -1,7 +1,9 @@
 from typing import IO, Any
+from unittest.mock import Mock
 
 import pytest
 
+from tilecloud_chain import DatedConfig
 from tilecloud_chain.views import admin
 
 
@@ -56,3 +58,68 @@ async def test_run_truncates_fallback_exception_message(monkeypatch: pytest.Monk
     assert result["error"] is True
     assert result["out"].endswith("\n...")
     assert len(result["out"]) <= 41
+
+
+@pytest.mark.asyncio
+async def test_validate_config_file_warns_about_reserved_wms_params(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "tilecloud_chain.views.admin.jsonschema_validator.validate",
+        Mock(return_value=([], None)),
+    )
+    config = DatedConfig(
+        config={
+            "layers": {
+                "test_layer": {
+                    "type": "wms",
+                    "url": "http://example.com/wms",
+                    "params": {
+                        "SRS": "EPSG:2056",
+                        "BBOX": "0,0,1,1",
+                        "CUSTOM": "valid_param",
+                    },
+                },
+                "good_layer": {
+                    "type": "wms",
+                    "url": "http://example.com/wms",
+                    "params": {
+                        "CUSTOM": "valid_param",
+                    },
+                },
+            },
+        },
+        mtime=0.0,
+        file=Mock(),
+    )
+
+    structure_errors, deprecation_warnings = await admin._validate_config_file(config)
+
+    assert structure_errors == []
+    assert len(deprecation_warnings) == 2
+    assert "test_layer" in deprecation_warnings[0]
+    assert "SRS" in deprecation_warnings[0]
+    assert "BBOX" in deprecation_warnings[1]
+
+
+@pytest.mark.asyncio
+async def test_validate_config_file_skips_non_wms_layers(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "tilecloud_chain.views.admin.jsonschema_validator.validate",
+        Mock(return_value=([], None)),
+    )
+    config = DatedConfig(
+        config={
+            "layers": {
+                "mapnik_layer": {
+                    "type": "mapnik",
+                    "params": {"SRS": "EPSG:2056"},
+                },
+            },
+        },
+        mtime=0.0,
+        file=Mock(),
+    )
+
+    structure_errors, deprecation_warnings = await admin._validate_config_file(config)
+
+    assert structure_errors == []
+    assert deprecation_warnings == []

--- a/tilecloud_chain/tests/test_generate.py
+++ b/tilecloud_chain/tests/test_generate.py
@@ -16,10 +16,12 @@ from PIL import Image
 from shapely.geometry import box
 from testfixtures import LogCapture
 from tilecloud import Tile, TileCoord
+from tilecloud.layout.wms import WMSTileLayout
 from tilecloud.store.redis import RedisTileStore
 
 import tilecloud_chain
 from tilecloud_chain import (
+    WMS_RESERVED_PARAMS,
     DatedConfig,
     HashLogger,
     IntersectGeometryFilter,
@@ -2001,3 +2003,59 @@ Tiles in error:
                 ) as file:
                     image = Image.open(file, formats=["WEBP"])
                     assert image.format == "WEBP"
+
+
+def test_wms_reserved_params_are_defined() -> None:
+    assert "LAYERS" in WMS_RESERVED_PARAMS
+    assert "FORMAT" in WMS_RESERVED_PARAMS
+    assert "SRS" in WMS_RESERVED_PARAMS
+    assert "CRS" in WMS_RESERVED_PARAMS
+    assert "BBOX" in WMS_RESERVED_PARAMS
+    assert "WIDTH" in WMS_RESERVED_PARAMS
+    assert "HEIGHT" in WMS_RESERVED_PARAMS
+    assert "SERVICE" in WMS_RESERVED_PARAMS
+    assert "REQUEST" in WMS_RESERVED_PARAMS
+    assert "TRANSPARENT" in WMS_RESERVED_PARAMS
+    assert "VERSION" not in WMS_RESERVED_PARAMS
+    assert "STYLES" not in WMS_RESERVED_PARAMS
+
+
+def test_wms_tile_layout_uses_crs_for_version_1_3_0() -> None:
+    from tilecloud import TileGrid
+
+    tilegrid = TileGrid(tile_size=256)
+    params = {"VERSION": "1.3.0"}
+
+    tile_layout = WMSTileLayout(
+        url="http://wms.example.com/wms",
+        layers="test",
+        srs="EPSG:2056",
+        format_pattern="image/png",
+        tilegrid=tilegrid,
+        params=params,
+    )
+
+    if params.get("VERSION", "").startswith("1.3"):
+        tile_layout.params["CRS"] = tile_layout.params.pop("SRS")
+
+    assert "SRS" not in tile_layout.params
+    assert tile_layout.params["CRS"] == "EPSG:2056"
+
+
+def test_wms_tile_layout_keeps_srs_for_version_1_1_1() -> None:
+    from tilecloud import TileGrid
+
+    tilegrid = TileGrid(tile_size=256)
+    params = {}
+
+    tile_layout = WMSTileLayout(
+        url="http://wms.example.com/wms",
+        layers="test",
+        srs="EPSG:21781",
+        format_pattern="image/png",
+        tilegrid=tilegrid,
+        params=params,
+    )
+
+    assert tile_layout.params["SRS"] == "EPSG:21781"
+    assert "CRS" not in tile_layout.params

--- a/tilecloud_chain/views/admin.py
+++ b/tilecloud_chain/views/admin.py
@@ -49,7 +49,7 @@ from pydantic import BaseModel
 
 import tilecloud_chain.server
 import tilecloud_chain.store.postgresql
-from tilecloud_chain import TileGeneration, configuration, controller, generate, server
+from tilecloud_chain import WMS_RESERVED_PARAMS, TileGeneration, configuration, controller, generate, server
 from tilecloud_chain.controller import get_status
 from tilecloud_chain.settings import settings
 
@@ -188,6 +188,15 @@ async def _validate_config_file(
                 )
             if layer.get("type") == "mapnik" and "wms_url" in layer:
                 deprecation_warnings.append(f"Layer '{layer_name}' uses 'wms_url' (deprecated).")
+            if layer.get("type") == "wms":
+                layer_wms = cast("tilecloud_chain.configuration.LayerWms", layer)
+                layer_params = layer_wms.get("params", {})
+                deprecation_warnings.extend(
+                    f"Layer '{layer_name}' has a reserved WMS parameter '{param}' in 'params'; "
+                    "this parameter is managed by the system and will be ignored."
+                    for param in layer_params
+                    if param.upper() in WMS_RESERVED_PARAMS
+                )
 
     return structure_errors, deprecation_warnings
 


### PR DESCRIPTION
## Summary

Filter out system-managed WMS parameters from user-provided `params` in layer configuration, handle the SRS-to-CRS conversion when WMS version is 1.3.0, and warn users when they set reserved parameters in the admin interface.

## Context

When a user sets `VERSION: 1.3.0` in the layer `params`, the WMS request still used `SRS` (WMS 1.1.1 parameter name) instead of `CRS` (WMS 1.3.0 parameter name), causing a 400 Bad Request from the WMS server.

## Implementation Details

- Added `WMS_RESERVED_PARAMS` constant in `configuration.py` with parameters that are always managed by the system (`LAYERS`, `FORMAT`, `TRANSPARENT`, `SERVICE`, `REQUEST`, `SRS`, `CRS`, `BBOX`, `WIDTH`, `HEIGHT`)
- In `generate.py`, filter out reserved params from user config with a log warning, and replace `SRS` with `CRS` when `VERSION=1.3.0`
- In `views/admin.py`, added validation that warns about reserved WMS parameters in the admin interface
- `VERSION` and `STYLES` are intentionally not reserved — users can still override them

## Impact/Risks

Low risk. Backward compatible — existing configurations without reserved params in `params` are unaffected.