### PR TITLE
Fix WMTS capabilities TileMatrixSetLimits handling when px_buffer is set

### DIFF
--- a/.github/spell-ignore-words.txt
+++ b/.github/spell-ignore-words.txt
@@ -15,3 +15,5 @@ geoms
 bbox
 mask.geojson
 te
+TileMatrixSetLimits
+px

--- a/tilecloud_chain/CONFIG.md
+++ b/tilecloud_chain/CONFIG.md
@@ -121,6 +121,7 @@
   - <a id="definitions/layer_bbox/items"></a>**Items** *(number)*
 - <a id="definitions/layer_min_resolution_seed"></a>**`layer_min_resolution_seed`** *(number)*: The minimum resolutions to pre-generate.
 - <a id="definitions/layer_px_buffer"></a>**`layer_px_buffer`** *(integer)*: The buffer in pixel used to calculate geometry intersection. Default: `0`.
+- <a id="definitions/layer_force_tile_matrix_set_limits"></a>**`layer_force_tile_matrix_set_limits`** *(boolean)*: When true, include TileMatrixSetLimits in WMTS capabilities even when px_buffer is set. Default: false. Default: `false`.
 - <a id="definitions/layer_geom_filter"></a>**`layer_geom_filter`** *(boolean)*: Enable the geometry intersection filter in the processing pipeline. Default: `true`.
 - <a id="definitions/layer_meta"></a>**`layer_meta`** *(boolean)*: Use meta-tiles, see https://github.com/camptocamp/tilecloud-chain/blob/master/tilecloud_chain/USAGE.rst#meta-tiles. Default: `false`.
 - <a id="definitions/layer_meta_size"></a>**`layer_meta_size`** *(integer)*: The meta-tile size in tiles. Default: `5`.
@@ -187,6 +188,7 @@
   - <a id="definitions/layer_wms/properties/bbox"></a>**`bbox`**: Refer to *[#/definitions/layer_bbox](#definitions/layer_bbox)*.
   - <a id="definitions/layer_wms/properties/min_resolution_seed"></a>**`min_resolution_seed`**: Refer to *[#/definitions/layer_min_resolution_seed](#definitions/layer_min_resolution_seed)*.
   - <a id="definitions/layer_wms/properties/px_buffer"></a>**`px_buffer`**: Refer to *[#/definitions/layer_px_buffer](#definitions/layer_px_buffer)*.
+  - <a id="definitions/layer_wms/properties/force_tile_matrix_set_limits"></a>**`force_tile_matrix_set_limits`**: Refer to *[#/definitions/layer_force_tile_matrix_set_limits](#definitions/layer_force_tile_matrix_set_limits)*.
   - <a id="definitions/layer_wms/properties/meta"></a>**`meta`**: Refer to *[#/definitions/layer_meta](#definitions/layer_meta)*.
   - <a id="definitions/layer_wms/properties/meta_size"></a>**`meta_size`**: Refer to *[#/definitions/layer_meta_size](#definitions/layer_meta_size)*. Default: `5`.
   - <a id="definitions/layer_wms/properties/meta_buffer"></a>**`meta_buffer`**: Refer to *[#/definitions/layer_meta_buffer](#definitions/layer_meta_buffer)*. Default: `128`.
@@ -226,6 +228,7 @@
   - <a id="definitions/layer_mapnik/properties/bbox"></a>**`bbox`**: Refer to *[#/definitions/layer_bbox](#definitions/layer_bbox)*.
   - <a id="definitions/layer_mapnik/properties/min_resolution_seed"></a>**`min_resolution_seed`**: Refer to *[#/definitions/layer_min_resolution_seed](#definitions/layer_min_resolution_seed)*.
   - <a id="definitions/layer_mapnik/properties/px_buffer"></a>**`px_buffer`**: Refer to *[#/definitions/layer_px_buffer](#definitions/layer_px_buffer)*.
+  - <a id="definitions/layer_mapnik/properties/force_tile_matrix_set_limits"></a>**`force_tile_matrix_set_limits`**: Refer to *[#/definitions/layer_force_tile_matrix_set_limits](#definitions/layer_force_tile_matrix_set_limits)*.
   - <a id="definitions/layer_mapnik/properties/meta"></a>**`meta`**: Refer to *[#/definitions/layer_meta](#definitions/layer_meta)*.
   - <a id="definitions/layer_mapnik/properties/meta_size"></a>**`meta_size`**: Refer to *[#/definitions/layer_meta_size](#definitions/layer_meta_size)*. Default: `1`.
   - <a id="definitions/layer_mapnik/properties/meta_buffer"></a>**`meta_buffer`**: Refer to *[#/definitions/layer_meta_buffer](#definitions/layer_meta_buffer)*. Default: `0`.

--- a/tilecloud_chain/USAGE.rst
+++ b/tilecloud_chain/USAGE.rst
@@ -83,6 +83,13 @@ When generating WMTS capabilities, if a layer ``bbox`` is defined, it is also us
 
 ``px_buffer`` a buffer in px around the object area (geoms or extent).
 
+When ``px_buffer`` is set to a non-zero value, the ``TileMatrixSetLimits`` are not
+included in the WMTS capabilities by default, because the expanded tile range
+can cause issues with OpenLayers tile grid extent calculation.
+
+To force the inclusion of ``TileMatrixSetLimits`` even when ``px_buffer`` is set,
+use ``force_tile_matrix_set_limits: true`` on the layer.
+
 ``geom_filter`` enable (default) or disable the geometry intersection filter in the
 generation pipeline.
 

--- a/tilecloud_chain/__init__.py
+++ b/tilecloud_chain/__init__.py
@@ -784,6 +784,13 @@ def get_tile_matrix_limits(
     if "bbox" not in layer:
         return []
 
+    px_buffer = float(layer.get("px_buffer", configuration.LAYER_PIXEL_BUFFER_DEFAULT))
+    force_limits = layer.get(
+        "force_tile_matrix_set_limits", configuration.FORCE_TILE_MATRIX_SET_LIMITS_DEFAULT
+    )
+    if px_buffer != 0 and not force_limits:
+        return []
+
     grid = config.config["grids"][grid_name]
     layer_bbox = normalize_bbox(layer["bbox"])
     if (

--- a/tilecloud_chain/configuration.py
+++ b/tilecloud_chain/configuration.py
@@ -865,6 +865,22 @@ r""" Default value of the field path 'Server expires' """
 
 
 
+FORCE_TILE_MATRIX_SET_LIMITS_DEFAULT = False
+r""" Default value of the field path 'layer_force_tile_matrix_set_limits' """
+
+
+
+ForceTileMatrixSetLimits = bool
+r"""
+Force tile matrix set limits.
+
+When true, include TileMatrixSetLimits in WMTS capabilities even when px_buffer is set. Default: false.
+
+default: False
+"""
+
+
+
 GENERATE_SALT_DEFAULT = False
 r""" Default value of the field path 'Layer WMS generate_salt' """
 
@@ -1625,6 +1641,15 @@ class LayerMapnik(TypedDict, total=False):
     default: 0
     """
 
+    force_tile_matrix_set_limits: "ForceTileMatrixSetLimits"
+    r"""
+    Force tile matrix set limits.
+
+    When true, include TileMatrixSetLimits in WMTS capabilities even when px_buffer is set. Default: false.
+
+    default: False
+    """
+
     meta: "LayerMeta"
     r"""
     Layer meta.
@@ -2029,6 +2054,15 @@ class LayerWms(TypedDict, total=False):
     The buffer in pixel used to calculate geometry intersection
 
     default: 0
+    """
+
+    force_tile_matrix_set_limits: "ForceTileMatrixSetLimits"
+    r"""
+    Force tile matrix set limits.
+
+    When true, include TileMatrixSetLimits in WMTS capabilities even when px_buffer is set. Default: false.
+
+    default: False
     """
 
     meta: "LayerMeta"

--- a/tilecloud_chain/schema.json
+++ b/tilecloud_chain/schema.json
@@ -296,6 +296,12 @@
       "type": "integer",
       "default": 0
     },
+    "layer_force_tile_matrix_set_limits": {
+      "title": "Force tile matrix set limits",
+      "description": "When true, include TileMatrixSetLimits in WMTS capabilities even when px_buffer is set. Default: false.",
+      "type": "boolean",
+      "default": false
+    },
     "layer_geom_filter": {
       "title": "Layer geometry filter",
       "description": "Enable the geometry intersection filter in the processing pipeline",
@@ -640,6 +646,9 @@
         "px_buffer": {
           "$ref": "#/definitions/layer_px_buffer"
         },
+        "force_tile_matrix_set_limits": {
+          "$ref": "#/definitions/layer_force_tile_matrix_set_limits"
+        },
         "meta": {
           "$ref": "#/definitions/layer_meta"
         },
@@ -776,6 +785,9 @@
         },
         "px_buffer": {
           "$ref": "#/definitions/layer_px_buffer"
+        },
+        "force_tile_matrix_set_limits": {
+          "$ref": "#/definitions/layer_force_tile_matrix_set_limits"
         },
         "meta": {
           "$ref": "#/definitions/layer_meta"

--- a/tilecloud_chain/tests/test_generate.py
+++ b/tilecloud_chain/tests/test_generate.py
@@ -590,6 +590,7 @@ def test_get_tile_matrix_limits_with_px_buffer() -> None:
                     "layer": {
                         "bbox": [560000.0, 180000.0, 550000.0, 170000.0],
                         "px_buffer": 100,
+                        "force_tile_matrix_set_limits": True,
                     },
                 },
                 "grids": {
@@ -616,6 +617,35 @@ def test_get_tile_matrix_limits_with_px_buffer() -> None:
             "max_tile_col": 5,
         },
     ]
+
+
+def test_get_tile_matrix_limits_with_px_buffer_no_force() -> None:
+    config = DatedConfig(
+        cast(
+            "tcc_configuration.Configuration",
+            {
+                "layers": {
+                    "layer": {
+                        "bbox": [560000.0, 180000.0, 550000.0, 170000.0],
+                        "px_buffer": 100,
+                    },
+                },
+                "grids": {
+                    "grid": {
+                        "bbox": [420000.0, 30000.0, 900000.0, 350000.0],
+                        "resolutions": [100.0],
+                        "tile_size": 256,
+                    },
+                },
+            },
+        ),
+        0,
+        AnyioPath("config.yaml"),
+    )
+
+    limits = get_tile_matrix_limits(config, "layer", "grid")
+
+    assert limits == []
 
 
 def test_get_geoms_respects_geometry_srid(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
When `px_buffer` is set on a layer, the `TileMatrixSetLimits` are now excluded
from WMTS capabilities by default, and replaced by a `BoundingBox` in the
`TileMatrixSet`. This avoids OpenLayers calculating a too-restrictive extent
from the most detailed level's limits, which caused no tiles to be requested.

A new force_tile_matrix_set_limits option allows forcing the inclusion of
`TileMatrixSetLimits` even when px_buffer is set.
