### PR TITLE
Improve Sentry error reporting by capturing the original exception

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -575,14 +575,14 @@ virtualenv = ["virtualenv (>=20.17) ; python_version >= \"3.10\" and python_vers
 
 [[package]]
 name = "c2casgiutils"
-version = "0.13.0"
+version = "0.13.1"
 description = "Common utilities for Camptocamp ASGI applications"
 optional = false
 python-versions = ">=3.11"
 groups = ["main"]
 files = [
-    {file = "c2casgiutils-0.13.0-py3-none-any.whl", hash = "sha256:ade3f06fe6a4aa37bf836b84110c828a6101ea46c6979efefb54f4a4246401b7"},
-    {file = "c2casgiutils-0.13.0.tar.gz", hash = "sha256:2f308a48881aca3d6672156f5b15eecd933aa1f6371600518df899bc3344c909"},
+    {file = "c2casgiutils-0.13.1-py3-none-any.whl", hash = "sha256:0d9779cf8dcc4ed32363ca5a78d03ab718a22d98984db8664b9b206aa1d4dae5"},
+    {file = "c2casgiutils-0.13.1.tar.gz", hash = "sha256:fafdcec7a2b1927bbc760fba19ffecb517a8f61bb16d322533acbffa0f6a4469"},
 ]
 
 [package.dependencies]
@@ -2858,34 +2858,9 @@ description = "Python package for creating and manipulating graphs and networks"
 optional = false
 python-versions = ">=3.11"
 groups = ["dev"]
-markers = "python_version == \"3.14\""
 files = [
     {file = "networkx-3.6-py3-none-any.whl", hash = "sha256:cdb395b105806062473d3be36458d8f1459a4e4b98e236a66c3a48996e07684f"},
     {file = "networkx-3.6.tar.gz", hash = "sha256:285276002ad1f7f7da0f7b42f004bcba70d381e936559166363707fdad3d72ad"},
-]
-
-[package.extras]
-benchmarking = ["asv", "virtualenv"]
-default = ["matplotlib (>=3.8)", "numpy (>=1.25)", "pandas (>=2.0)", "scipy (>=1.11.2)"]
-developer = ["mypy (>=1.15)", "pre-commit (>=4.1)"]
-doc = ["intersphinx-registry", "myst-nb (>=1.1)", "numpydoc (>=1.8.0)", "pillow (>=10)", "pydata-sphinx-theme (>=0.16)", "sphinx (>=8.0)", "sphinx-gallery (>=0.18)", "texext (>=0.6.7)"]
-example = ["cairocffi (>=1.7)", "contextily (>=1.6)", "igraph (>=0.11)", "iplotx (>=0.9.0)", "momepy (>=0.7.2)", "osmnx (>=2.0.0)", "scikit-learn (>=1.5)", "seaborn (>=0.13)"]
-extra = ["lxml (>=4.6)", "pydot (>=3.0.1)", "pygraphviz (>=1.14)", "sympy (>=1.10)"]
-release = ["build (>=0.10)", "changelist (==0.5)", "twine (>=4.0)", "wheel (>=0.40)"]
-test = ["pytest (>=7.2)", "pytest-cov (>=4.0)", "pytest-xdist (>=3.0)"]
-test-extras = ["pytest-mpl", "pytest-randomly"]
-
-[[package]]
-name = "networkx"
-version = "3.6.1"
-description = "Python package for creating and manipulating graphs and networks"
-optional = false
-python-versions = "!=3.14.1,>=3.11"
-groups = ["dev"]
-markers = "python_version < \"3.14\""
-files = [
-    {file = "networkx-3.6.1-py3-none-any.whl", hash = "sha256:d47fbf302e7d9cbbb9e2555a0d267983d2aa476bac30e90dfbe5669bd57f3762"},
-    {file = "networkx-3.6.1.tar.gz", hash = "sha256:26b7c357accc0c8cde558ad486283728b65b6a95d85ee1cd66bafab4c8168509"},
 ]
 
 [package.extras]
@@ -5442,7 +5417,6 @@ description = "Read and write TIFF files"
 optional = false
 python-versions = ">=3.11"
 groups = ["dev"]
-markers = "python_version == \"3.11\""
 files = [
     {file = "tifffile-2026.3.3-py3-none-any.whl", hash = "sha256:e8be15c94273113d31ecb7aa3a39822189dd11c4967e3cc88c178f1ad2fd1170"},
     {file = "tifffile-2026.3.3.tar.gz", hash = "sha256:d9a1266bed6f2ee1dd0abde2018a38b4f8b2935cb843df381d70ac4eac5458b7"},
@@ -5458,30 +5432,6 @@ plot = ["matplotlib"]
 test = ["cmapfile", "czifile", "dask", "defusedxml", "fsspec", "imagecodecs", "kerchunk", "lfdfiles", "lxml", "ndtiff", "oiffile", "psdtags", "pytest", "requests", "roifile", "xarray", "zarr (>=3.1.5)"]
 xml = ["defusedxml", "lxml"]
 zarr = ["fsspec", "kerchunk", "zarr (>=3.1.5)"]
-
-[[package]]
-name = "tifffile"
-version = "2026.5.2"
-description = "Read and write TIFF files"
-optional = false
-python-versions = ">=3.12"
-groups = ["dev"]
-markers = "python_version >= \"3.12\""
-files = [
-    {file = "tifffile-2026.5.2-py3-none-any.whl", hash = "sha256:5129b53b826e768a5b1af26b765eeea75c2d0a227d2d12849617e0737588e105"},
-    {file = "tifffile-2026.5.2.tar.gz", hash = "sha256:21b10227ede8493814a34676774797f721f487e36cb0530e7c3bd882caa87f5a"},
-]
-
-[package.dependencies]
-numpy = ">=2.1"
-
-[package.extras]
-all = ["fsspec", "imagecodecs (>=2026.3.6)", "kerchunk", "lxml", "matplotlib", "xarray", "zarr (>=3.2.0)"]
-codecs = ["imagecodecs (>=2026.3.6)"]
-plot = ["matplotlib"]
-test = ["cmapfile", "czifile", "dask", "fsspec", "imagecodecs", "kerchunk", "lfdfiles", "lxml", "ndtiff", "oiffile", "psdtags", "pytest", "requests", "roifile", "xarray", "zarr (>=3.2.0)"]
-xml = ["lxml"]
-zarr = ["fsspec", "kerchunk", "zarr (>=3.2.0)"]
 
 [[package]]
 name = "tilecloud"
@@ -5718,15 +5668,15 @@ typing-extensions = ">=4.12.0"
 
 [[package]]
 name = "tzdata"
-version = "2026.2"
+version = "2026.3"
 description = "Provider of IANA time zone data"
 optional = false
 python-versions = ">=2"
 groups = ["main"]
 markers = "sys_platform == \"win32\""
 files = [
-    {file = "tzdata-2026.2-py2.py3-none-any.whl", hash = "sha256:bbe9af844f658da81a5f95019480da3a89415801f6cc966806612cc7169bffe7"},
-    {file = "tzdata-2026.2.tar.gz", hash = "sha256:9173fde7d80d9018e02a662e168e5a2d04f87c41ea174b139fbef642eda62d10"},
+    {file = "tzdata-2026.3-py2.py3-none-any.whl", hash = "sha256:dc096730c87af6cab1b171c9d532be840741ff5d459015e7f6947bd7d7e54931"},
+    {file = "tzdata-2026.3.tar.gz", hash = "sha256:4a1518b8993086a7982523e071643f3c0e5f213e75b21318e78bcabfff9d1415"},
 ]
 
 [[package]]
@@ -6491,4 +6441,4 @@ test = ["zope.testing"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<3.15"
-content-hash = "e5283acc41d211cccf5d410e0a0a2fc3487f507bb32388c23966d1469747a6f0"
+content-hash = "44991695255ac5f0a59f48e5e1a42799941c5cf2667179c200eff16e858ec549"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ version = "0.0.0"
 [tool.poetry.dependencies]
 # Minimal version should also be set in the jsonschema-gentypes.yaml file
 python = ">=3.11,<3.15"
-c2casgiutils = { version = "0.13.0", extras = ["all"] }
+c2casgiutils = { version = "0.13.1", extras = ["all"] }
 fastapi = {extras = ["standard"], version = "0.136.3"}
 python-dateutil = "2.9.0.post0"
 tilecloud = { version = "1.13.5", extras = ["azure", "aws", "redis", "wsgi"] }

--- a/tilecloud_chain/internal_mapcache.py
+++ b/tilecloud_chain/internal_mapcache.py
@@ -11,6 +11,7 @@ from collections.abc import AsyncIterator
 from typing import TYPE_CHECKING, Any, NamedTuple, cast
 
 import redis.asyncio as aioredis
+import sentry_sdk
 import yaml
 from fastapi import Response
 from prometheus_client import Summary
@@ -286,6 +287,8 @@ async def fetch(
                 backend = "wms-generate"
                 success = await generator.compute_tile(meta_tile)
                 if not success:
+                    if isinstance(meta_tile.error, BaseException):
+                        sentry_sdk.capture_exception(meta_tile.error)
                     return server.error(config, 500, "Error while generate the tile, see logs for details")
 
                 if meta_tile.error:
@@ -295,6 +298,8 @@ async def fetch(
                         meta_tile.formated_metadata,
                         meta_tile.error,
                     )
+                    if isinstance(meta_tile.error, BaseException):
+                        sentry_sdk.capture_exception(meta_tile.error)
                     return server.error(config, 502, "Error while generate the tile, see logs for details")
 
                 # Don't fetch the just generated tile


### PR DESCRIPTION
## Summary

Improve Sentry error reporting in the tile generation pipeline by capturing the original exception (e.g. SSL certificate errors) before returning the generic HTTP response.

## Context

The Sentry issue https://camptocamp.sentry.io/issues/7620107597/ showed only a generic `HTTPException: Error while generate the tile, see logs for details` message, making it hard to diagnose the root cause. The actual error (SSL certificate verification failure) was only in the logs.

## Implementation Details

- In `tilecloud_chain/internal_mapcache.py`, use `sentry_sdk.capture_exception()` to send the original exception from `meta_tile.error` to Sentry before returning the generic HTTP response.
- The HTTP response stays generic (`Error while generate the tile, see logs for details`) to avoid leaking infrastructure details.
- Also update `c2casgiutils` to version 0.13.1.

## Impact/Risks

- Low risk: changes are minimal and only affect error reporting paths
- No backward compatibility impact