### PR TITLE
Subscribe to Redis log level changes in the tile generator

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -71,6 +71,7 @@ RUN --mount=type=cache,target=/root/.cache \
 CMD ["uvicorn", "tilecloud_chain.main:app", "--host=0.0.0.0", "--port=8080", "--log-config=/app/logging.yaml"]
 
 EXPOSE 8080
+ENV C2C__TOOLS__LOGGING__APPLICATION_MODULE=tilecloud_chain
 
 # Do the lint, used by the tests
 FROM base AS tests
@@ -127,7 +128,6 @@ COPY . ./
 RUN --mount=type=cache,target=/root/.cache \
     POETRY_DYNAMIC_VERSIONING_BYPASS=0.0.0 python3 -m pip install --disable-pip-version-check --no-deps --editable=. \
     && python3 -m pip freeze > /requirements.txt
-
 
 # Set runner as final
 FROM runner

--- a/tilecloud_chain/__init__.py
+++ b/tilecloud_chain/__init__.py
@@ -35,6 +35,7 @@ from typing import IO, TYPE_CHECKING, Any, Literal, NamedTuple, TextIO, TypedDic
 
 import anyio
 import boto3
+import c2casgiutils
 import c2cwsgiutils.pyramid_logging
 import c2cwsgiutils.setup_process
 import jsonschema_validator
@@ -1031,6 +1032,11 @@ class TileGeneration:
     ) -> None:
         """Initialize the tile generation."""
         assert "generation" in (await self.get_main_config()).config, (await self.get_main_config()).config
+
+        # Initialize Redis broadcast to receive dynamic log level changes
+        # from the c2casgiutils web UI (e.g., /c2c/logging/level endpoint)
+        await c2casgiutils.broadcast.startup()
+        await c2casgiutils.tools.logging_.startup()
 
         error = False
         if self.options is not None and self.options.zoom is not None:


### PR DESCRIPTION
## Summary

Initialize the c2casgiutils Redis broadcast subscription in `TileGeneration.ainit()` so that the tile generator process receives dynamic log level changes made via the web UI (`POST /c2c/logging/level`).

## Context

When a user changes the log level via the c2casgiutils web UI, the change is published to a Redis pub/sub channel (`broadcast_api_c2c_decorated_c2casgiutils.tools.logging_.__set_level`). The tile generator process was not subscribed to this channel, so it never received those changes.

The level overrides are also persisted in Redis (keys `c2c_logging_level_*`) and are now restored on tile generator startup via `logging_.startup()`.

## Implementation Details

- Added `import c2casgiutils` in `tilecloud_chain/__init__.py`
- Added `await c2casgiutils.broadcast.startup()` and `await c2casgiutils.tools.logging_.startup()` at the beginning of `TileGeneration.ainit()`
- Both functions accept `None` for the app parameter and work outside FastAPI context
- They are idempotent — safe to call even when the web server has already initialized them
- Added `C2C__TOOLS__LOGGING__APPLICATION_MODULE=tilecloud_chain` env var in the Dockerfile so that c2casgiutils logging tools can identify the application module

## Impact/Risks

- No impact on the web server path — it already uses `configure_logging=False` and `c2casgiutils.startup()` is called in `main.py:_lifespan`
- If Redis is not configured, it falls back to `LocalBroadcaster` (no-op, same behavior as before)
- The `dictConfig` call in `__init__` still sets initial log levels from environment variables at startup — the Redis subscription then allows dynamic changes afterward

<!-- pull request links -->
See JIRA issue: [GSEPF-1046](https://camptocamp.atlassian.net/browse/GSEPF-1046).

[GSEPF-1046]: https://camptocamp.atlassian.net/browse/GSEPF-1046?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ