### PR TITLE
Add async FilesystemTileStore and fix directory creation race condition

### DIFF
--- a/tilecloud_chain/__init__.py
+++ b/tilecloud_chain/__init__.py
@@ -59,7 +59,6 @@ from tilecloud.filter.error import LogErrors
 from tilecloud.filter.logger import Logger
 from tilecloud.grid.free import FreeTileGrid
 from tilecloud.layout.wmts import WMTSTileLayout
-from tilecloud.store.filesystem import FilesystemTileStore
 from tilecloud.store.mbtiles import MBTilesTileStore
 from tilecloud.store.metatile import MetaTileSplitterTileStore
 from tilecloud.store.redis import RedisTileStore
@@ -77,6 +76,7 @@ from tilecloud_chain.store import (
     TileStoreWrapper,
 )
 from tilecloud_chain.store.azure_storage_blob import AzureStorageBlobTileStore
+from tilecloud_chain.store.filesystem import FilesystemTileStore
 from tilecloud_chain.timedtilestore import TimedTileStoreWrapper
 
 if TYPE_CHECKING:
@@ -1426,11 +1426,9 @@ class TileGeneration:
             )
         elif cache["type"] == "filesystem":
             # on filesystem
-            cache_tilestore = TileStoreWrapper(
-                FilesystemTileStore(
-                    layout,
-                    content_type=layer["mime_type"],
-                ),
+            cache_tilestore = FilesystemTileStore(
+                layout,
+                content_type=layer["mime_type"],
             )
         else:
             sys.exit("unknown cache type: " + cache["type"])

--- a/tilecloud_chain/store/filesystem.py
+++ b/tilecloud_chain/store/filesystem.py
@@ -1,0 +1,88 @@
+"""Async filesystem tile store."""
+
+import errno
+import logging
+from collections.abc import AsyncIterator
+from typing import Any
+
+from anyio import Path
+from tilecloud import Tile, TileLayout
+
+from tilecloud_chain.store import AsyncTileStore
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class FilesystemTileStore(AsyncTileStore):
+    """Tiles stored in a filesystem, async version."""
+
+    def __init__(self, tilelayout: TileLayout, **kwargs: Any) -> None:
+        self.tilelayout = tilelayout
+        self.content_type = kwargs.get("content_type")
+
+    async def delete_one(self, tile: Tile) -> Tile:
+        """Delete one tile."""
+        try:
+            filename = self.tilelayout.filename(tile.tilecoord, tile.metadata)
+        except Exception as exception:  # noqa: BLE001
+            _LOGGER.warning("Error while deleting tile %s", tile, exc_info=True)
+            tile.error = exception
+            return tile
+        path = Path(filename)
+        if await path.exists():
+            await path.unlink()
+        return tile
+
+    async def get_one(self, tile: Tile) -> Tile | None:
+        """Get one tile."""
+        try:
+            filename = self.tilelayout.filename(tile.tilecoord, tile.metadata)
+        except Exception as exception:  # noqa: BLE001
+            _LOGGER.warning("Error while getting tile %s", tile, exc_info=True)
+            tile.error = exception
+            return tile
+        path = Path(filename)
+        try:
+            async with await path.open("rb") as file:
+                tile.data = await file.read()
+        except OSError as exception:
+            if exception.errno == errno.ENOENT:
+                return None
+            raise
+        if self.content_type is not None:
+            tile.content_type = self.content_type
+        return tile
+
+    async def list(self) -> AsyncIterator[Tile]:
+        """List all tiles."""
+        top = getattr(self.tilelayout, "prefix", ".")
+        top_path = Path(top)
+        async for path in top_path.glob("**/*"):
+            if await path.is_file():
+                tilecoord = self.tilelayout.tilecoord(str(path))
+                if tilecoord:
+                    yield Tile(tilecoord, path=str(path))
+
+    async def put_one(self, tile: Tile) -> Tile:
+        """Put one tile."""
+        assert isinstance(tile.data, bytes)
+        try:
+            filename = self.tilelayout.filename(tile.tilecoord, tile.metadata)
+        except Exception as exception:  # noqa: BLE001
+            _LOGGER.warning("Error while putting tile %s", tile, exc_info=True)
+            tile.error = exception
+            return tile
+        path = Path(filename)
+        await path.parent.mkdir(parents=True, exist_ok=True)
+        async with await path.open("wb") as file:
+            await file.write(tile.data)
+        return tile
+
+    async def __contains__(self, tile: Tile) -> bool:
+        try:
+            filename = self.tilelayout.filename(tile.tilecoord, tile.metadata)
+        except Exception as exception:  # noqa: BLE001
+            _LOGGER.warning("Error while putting tile %s", tile, exc_info=True)
+            tile.error = exception
+            return False
+        return await Path(filename).exists()


### PR DESCRIPTION
## Summary

Replace the synchronous `FilesystemTileStore` from the upstream `tilecloud` library with a local async implementation that fixes a race condition in directory creation and avoids blocking the event loop.

## Context

- The upstream `FilesystemTileStore.put_one()` uses `os.makedirs(dirname)` without `exist_ok=True`, causing `FileExistsError` race conditions when multiple concurrent tasks try to create the same parent directory simultaneously.
- Synchronous file I/O (`open`, `write`, `os.path.exists`) blocks the async event loop.
- The `TileStoreWrapper` wrapping was needed to make the sync store async-compatible; the new store inherits from `AsyncTileStore` directly.

## Implementation Details

- Created `tilecloud_chain/store/filesystem.py` with an async `FilesystemTileStore` class:
  - Uses `anyio.Path` for all filesystem operations (async).
  - Uses `path.parent.mkdir(parents=True, exist_ok=True)` instead of the TOCTOU-prone `os.path.exists()` + `os.makedirs()` pattern.
  - Implements `put_one`, `get_one`, `delete_one`, and `list` as async methods.
  - Matches the upstream error handling patterns (broad `except Exception` around layout.filename(), `OSError` with `ENOENT` for missing files).
- Updated `tilecloud_chain/__init__.py`:
  - Changed import from `tilecloud.store.filesystem` to the local `tilecloud_chain.store.filesystem`.
  - Removed `TileStoreWrapper` wrapping for the filesystem cache type (no longer needed).
- Removed the upstream `tilecloud.store.filesystem` import (no other references in the project).

## Impact/Risks

- No backward compatibility impact: the new class implements the same `AsyncTileStore` interface.
- The `list()` method now uses `glob('**/*')` instead of `os.walk` — behavior should be equivalent for sane directory trees.
- The `get_all()` method from the upstream is omitted (was never used).

<!-- pull request links -->
See JIRA issue: [GSEPF-1046](https://camptocamp.atlassian.net/browse/GSEPF-1046).

[GSEPF-1046]: https://camptocamp.atlassian.net/browse/GSEPF-1046?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ