### PR TITLE
Display generation errors from PostgreSQL in the admin UI

### DIFF
--- a/tilecloud_chain/views/admin.py
+++ b/tilecloud_chain/views/admin.py
@@ -223,8 +223,14 @@ async def admin_index(
     if config.file and has_access:
         structure_errors, deprecation_warnings = await _validate_config_file(config)
 
+    errors: list[str] = []
     if queue_store == "postgresql" and has_access and _postgresql_store and config.file:
         jobs_status = await _postgresql_store.get_status(config.file)
+        if jobs_status:
+            all_errors: list[str] = []
+            for _, _, job_errors, _ in jobs_status:
+                all_errors.extend(job_errors)
+            errors = all_errors[:5]
 
     try:
         nonce = request.state.nonce
@@ -250,6 +256,7 @@ async def admin_index(
         "urlencode": urllib.parse.urlencode,
         "structure_errors": structure_errors,
         "deprecation_warnings": deprecation_warnings,
+        "errors": errors,
     }
     return _templates.TemplateResponse("admin_index.html", context)
 


### PR DESCRIPTION
## Summary

Extract the last 5 errors from PostgreSQL job status and pass them to the template so the "Errors occur during the generation (max 5)" section in the admin UI actually displays errors.

## Context

The admin index template (`admin_index.html`) has a section `{% if errors %}` that renders generation errors, but the `errors` variable was never passed in the Jinja context. The `get_status()` in `PostgresqlTileStore` already returns the last 5 errors per job — they just weren't extracted and passed to the template.

## Implementation Details

- In `admin_index()`, after calling `_postgresql_store.get_status()`, extract the errors from each job (3rd element of each tuple: `list[str]`) and collect the first 5.
- Added `errors` to the Jinja context.
- For non-PostgreSQL queue stores, `errors` remains an empty list and the template section stays hidden (unchanged behavior).

## Impact/Risks

- Low risk: only affects the PostgreSQL queue store path, no changes to Redis/SQS behavior.
- Errors are fetched fresh on each page load.
- Template already escapes content via `escape` filter.

<!-- pull request links -->
See JIRA issue: [GSEPF-1046](https://camptocamp.atlassian.net/browse/GSEPF-1046).

[GSEPF-1046]: https://camptocamp.atlassian.net/browse/GSEPF-1046?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ