### PR TITLE
Restore TILECLOUD_CHAIN__HOST_CONCURRENT environment variable support

### DIFF
--- a/tilecloud_chain/HOST_LIMIT.md
+++ b/tilecloud_chain/HOST_LIMIT.md
@@ -5,7 +5,7 @@ _The configuration of the concurrent request limit on a host_
 ## Properties
 
 - <a id="properties/default"></a>**`default`** _(object)_
-  - <a id="properties/default/properties/concurrent"></a>**`concurrent`** _(integer)_: Default limit of concurrent request on the same host (can be set with the `TILECLOUD_CHAIN_HOST_CONCURRENT` environment variable. Default: `1`.
+  - <a id="properties/default/properties/concurrent"></a>**`concurrent`** _(integer)_: Default limit of concurrent request on the same host (can be set with the `TILECLOUD_CHAIN__HOST_CONCURRENT` environment variable).
 - <a id="properties/hosts"></a>**`hosts`** _(object)_: Can contain additional properties.
   - <a id="properties/hosts/additionalProperties"></a>**Additional properties** _(object)_
     - <a id="properties/hosts/additionalProperties/properties/concurrent"></a>**`concurrent`** _(integer)_: Limit of concurrent request on the host.

--- a/tilecloud_chain/USAGE.rst
+++ b/tilecloud_chain/USAGE.rst
@@ -837,6 +837,9 @@ Tile generation:
 - ``TILECLOUD_CHAIN__HOSTS_LIMIT``: File that contains the maximum request per host
   (default: ``/etc/tilegeneration/hosts_limit.yaml``)
 
+- ``TILECLOUD_CHAIN__HOST_CONCURRENT``: Default limit of concurrent requests on the same host
+  (default: ``1``)
+
 - ``TILECLOUD_CHAIN__IGNORE_CONFIG_ERROR``: Ignore configuration errors if set to ``true``
   (default: ``false``)
 

--- a/tilecloud_chain/host-limit-schema.json
+++ b/tilecloud_chain/host-limit-schema.json
@@ -14,8 +14,7 @@
         "concurrent": {
           "type": "integer",
           "title": "Default concurrent limit",
-          "description": "Default limit of concurrent request on the same host (can be set with the `TILECLOUD_CHAIN_HOST_CONCURRENT` environment variable.",
-          "default": 1
+          "description": "Default limit of concurrent request on the same host (can be set with the `TILECLOUD_CHAIN__HOST_CONCURRENT` environment variable)"
         }
       }
     },

--- a/tilecloud_chain/host_limit.py
+++ b/tilecloud_chain/host_limit.py
@@ -6,11 +6,6 @@ Automatically generated file from a JSON schema.
 from typing import TypedDict
 
 
-DEFAULT_CONCURRENT_LIMIT_DEFAULT = 1
-r""" Default value of the field path 'Default values concurrent' """
-
-
-
 class DefaultValues(TypedDict, total=False):
     r""" Default values. """
 
@@ -18,9 +13,7 @@ class DefaultValues(TypedDict, total=False):
     r"""
     Default concurrent limit.
 
-    Default limit of concurrent request on the same host (can be set with the `TILECLOUD_CHAIN_HOST_CONCURRENT` environment variable.
-
-    default: 1
+    Default limit of concurrent request on the same host (can be set with the `TILECLOUD_CHAIN__HOST_CONCURRENT` environment variable)
     """
 
 

--- a/tilecloud_chain/settings.py
+++ b/tilecloud_chain/settings.py
@@ -146,6 +146,7 @@ class Settings(BaseSettings):
     main_config_file: OptionalAnyioPath = None
     hosts_file: AnyioPath = Path("/etc/tilegeneration/hosts.yaml")
     hosts_limit: AnyioPath = Path("/etc/tilegeneration/hosts_limit.yaml")
+    host_concurrent: int = 1
     ignore_config_error: bool = False
     max_generation_time: int = 60
     allowed_process_commands: StrList = ["optipng", "jpegoptim", "pngquant"]

--- a/tilecloud_chain/store/url.py
+++ b/tilecloud_chain/store/url.py
@@ -106,7 +106,7 @@ class URLTileStore(AsyncTileStore):
                     .get("default", {})
                     .get(
                         "concurrent",
-                        host_limit.DEFAULT_CONCURRENT_LIMIT_DEFAULT,
+                        settings.host_concurrent,
                     ),
                 )
             )

--- a/tilecloud_chain/tests/test_url_store.py
+++ b/tilecloud_chain/tests/test_url_store.py
@@ -5,7 +5,9 @@ from unittest.mock import patch
 
 import aiohttp
 import pytest
+from tilecloud import Tile, TileCoord, TileLayout
 
+from tilecloud_chain.settings import settings
 from tilecloud_chain.store.url import URLTileStore
 
 
@@ -34,3 +36,24 @@ class TestURLTileStore:
         with patch.object(store._session, "close", side_effect=aiohttp.ClientConnectionError):
             await store.close()
         assert "Ignored error during aiohttp session close" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_host_concurrent_fallback(self) -> None:
+        """Test that TILECLOUD_CHAIN__HOST_CONCURRENT is used as fallback."""
+        tile_layout = TileLayout()
+        tile_layout.filename = lambda tc, md: "http://example.com/0/0/0.png"
+        store = URLTileStore([tile_layout])
+        original_host_concurrent = settings.host_concurrent
+        settings.host_concurrent = 5
+        try:
+            with (
+                patch.object(store, "_get_hosts_limit", return_value={}),
+                patch.object(store._session, "get") as mock_get,
+            ):
+                mock_get.return_value.__aenter__.return_value.status = 404
+                tile = Tile(TileCoord(0, 0, 0))
+                await store.get_one(tile)
+            semaphore = store._hosts_semaphore["example.com"]
+            assert semaphore._value == 5
+        finally:
+            settings.host_concurrent = original_host_concurrent


### PR DESCRIPTION
## Summary

Restore the ability to set the default host concurrent limit via the `TILECLOUD_CHAIN__HOST_CONCURRENT` environment variable.

## Context

The environment variable was documented in the host-limit JSON schema but never actually implemented. The fallback for the default concurrent limit was hardcoded to 1.

## Implementation Details

- Add `host_concurrent` field to the `Settings` class (mapped to `TILECLOUD_CHAIN__HOST_CONCURRENT` via the `env_prefix`)
- Use `settings.host_concurrent` as the fallback in `URLTileStore.get_one()` instead of the hardcoded `DEFAULT_CONCURRENT_LIMIT_DEFAULT`
- Fix the environment variable name in the schema (single underscore `TILECLOUD_CHAIN_HOST_CONCURRENT` to double underscore `TILECLOUD_CHAIN__HOST_CONCURRENT`)
- Close the unclosed parenthesis in the schema description
- Regenerate `host_limit.py` and `HOST_LIMIT.md`
- Document the environment variable in `USAGE.rst`

## Impact/Risks

None. This is additive — the default value remains 1, so existing configurations are unaffected.