### PR TITLE
Preserve existing loggers when reconfiguring logging via dictConfig

### DIFF
--- a/tilecloud_chain/__init__.py
+++ b/tilecloud_chain/__init__.py
@@ -990,6 +990,7 @@ class TileGeneration:
             logging.config.dictConfig(
                 {
                     "version": 1,
+                    "disable_existing_loggers": False,  # Don't disable loggers created before this dictConfig call (e.g. worker loggers)
                     "root": {
                         "level": settings.logging.other_log_level,
                         "handlers": [settings.logging.log_type],


### PR DESCRIPTION
## Summary

Fix log messages being silently dropped in worker processes when the admin runs tile generation commands.

## Context

The `logging.config.dictConfig` call in `TileGeneration.__init__` was using the default `disable_existing_loggers=True`, which disabled all loggers not explicitly listed in the configuration. This caused log messages from worker, admin, and server modules to be silently discarded because their loggers were marked as disabled after the reconfiguration.

The symptom was: error messages visible in the admin UI (from `print()` to `self.out`) but no corresponding log entries or exception tracebacks in the server/worker console.

## Implementation Details

Added `disable_existing_loggers: False` to the `dictConfig` call to preserve loggers created before the reconfiguration.