### PR TITLE
Add ORDER BY created_at to job selection queries

### DIFF
--- a/tilecloud_chain/store/postgresql.py
+++ b/tilecloud_chain/store/postgresql.py
@@ -639,7 +639,8 @@ class PostgresqlTileStore(AsyncTileStore):
                 result = await session.execute(
                     select(Job)
                     .with_for_update(of=Job, skip_locked=True)
-                    .where(Job.status == _STATUS_CREATED),
+                    .where(Job.status == _STATUS_CREATED)
+                    .order_by(Job.created_at),
                 )
                 job = result.scalar()
                 if job is not None:
@@ -662,7 +663,8 @@ class PostgresqlTileStore(AsyncTileStore):
                 result = await session.execute(
                     select(Job)
                     .with_for_update(of=Job, skip_locked=True)
-                    .where(Job.status == _STATUS_STARTED),
+                    .where(Job.status == _STATUS_STARTED)
+                    .order_by(Job.created_at),
                 )
                 for job in result.scalars():
                     nb_messages = await session.scalar(


### PR DESCRIPTION
## Summary

Add `.order_by(Job.created_at)` to both job selection queries in `_maintenance()` to guarantee FIFO ordering.

## Context

When two jobs are created from the admin interface close together, the second job could run before the first because PostgreSQL returns rows in non-deterministic order when no ORDER BY clause is specified.

## Implementation Details

- Added `.order_by(Job.created_at)` to the query that picks up `created` jobs (line 643)
- Added `.order_by(Job.created_at)` to the query that checks `started` jobs for completion (line 667) for consistency