### PR TITLE
Add missing ORDER BY to started jobs query in _maintenance

### DIFF
--- a/tilecloud_chain/templates/admin_index.html
+++ b/tilecloud_chain/templates/admin_index.html
@@ -226,26 +226,18 @@
               {% if 'generate' in s %}
               <!---->
               {% set comma = true %}
-              <span class="text-success-emphasis">{{ s['generate'] }} meta tiles to generate</span>
-              {% endif %}
-              <!---->
-              {% if 'pending' in s %}
-              <!---->
-              {% if comma %}
-              <!---->
-              ,
+              <span class="text-success-emphasis">{{ s['generate'] }} meta tiles to generate</span>{%
+                endif %}{%
+                if 'pending' in s %}{%
+                if comma %},
               <!---->
               {% endif %}
               <!---->
               {% set comma = true %}
-              <span class="text-primary-emphasis">{{ s['pending'] }} meta tiles being generated</span>
-              {% endif %}
-              <!---->
-              {% if 'error' in s %}
-              <!---->
-              {% if comma %}
-              <!---->
-              ,
+              <span class="text-primary-emphasis">{{ s['pending'] }} meta tiles being generated</span>{%
+                endif %}{%
+                if 'error' in s %}{%
+                  if comma %},
               <!---->
               {% endif %}
               <span class="text-danger-emphasis">{{ s['error'] }} meta tiles in error</span>


### PR DESCRIPTION
## Summary

Add the missing `.order_by(Job.created_at)` to the third job selection query in `_maintenance()` that populates the `self.jobs` dictionary.

## Context

Commit 78dce963 added `ORDER BY created_at` to two of the three job selection queries in `_maintenance()` but missed the one at line 699. Without this ordering, PostgreSQL may return started jobs in arbitrary order, causing the second-created job to be processed before the first when multiple jobs are started simultaneously.

## Implementation Details

Added `.order_by(Job.created_at)` to the `select(Job).where(Job.status == _STATUS_STARTED)` query at the end of `_maintenance()`, consistent with the other two queries at lines 643 and 667.