### PR TITLE
Pin ruff and pylint in the project

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -6446,4 +6446,4 @@ test = ["zope.testing"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<3.15"
-content-hash = "09669d5171ca21423366e44f4cb388da2002c51119851d39e386b0305657c8b9"
+content-hash = "9fb0c8b3f3e5518e0eb6b504756934178284a233912a21cfd2cac0b31cb62f8c"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,8 @@ types-requests = "2.33.0.20260712"
 pytest-asyncio = "1.4.0"
 pytest-check = "2.9.1"
 types-pyyaml = "6.0.12.20260724"
+ruff = "0.15.12"
+pylint = "4.0.5"
 
 [tool.poetry-dynamic-versioning]
 enable = true


### PR DESCRIPTION
Prospector uses ruff and pylint, they should be pinned alongside prospector.