### PR TITLE
Replace --die-on-tool-error by --direct-tool-stdout in prospector

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ checks: prospector ## Run the checks
 
 .PHONY: prospector
 prospector: ## Run Prospector
-	docker run --rm --volume=${PWD}:/app camptocamp/tilecloud-chain-tests prospector --output-format=pylint --die-on-tool-error --direct-tool-stdout
+	docker run --rm --volume=${PWD}:/app camptocamp/tilecloud-chain-tests prospector --output-format=pylint --direct-tool-stdout
 
 .PHONY: tests
 tests: build ## Run the unit tests


### PR DESCRIPTION
Prospector --die-on-tool-error is replaced by --direct-tool-stdout.