### PR TITLE
Allow PostgreSQL workers to pick meta-tiles from any started job

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 - Fix PostgreSQL admin retry action so it requeues only errored meta tiles instead of restarting full queue seeding for the whole job.
 - Add Python 3.14 support and use the PyPI Mapnik bindings instead of the removed Ubuntu `python3-mapnik` package.
 - Mark PostgreSQL metatile queue entries as `error` (instead of deleting them) when a child tile fails during write/store, so generation failures are visible in job status.
+- Allow PostgreSQL queue workers to pick meta-tiles from any started job when the current job has only pending meta-tiles, so workers are not blocked waiting for other workers to finish.
 
 Environment variable migration (legacy -> new)
 

--- a/tilecloud_chain/store/postgresql.py
+++ b/tilecloud_chain/store/postgresql.py
@@ -729,14 +729,7 @@ class PostgresqlTileStore(AsyncTileStore):
 
             if self.jobs:
                 config_filename = None
-                try:
-                    config_filename = next(iter(self.jobs))
-                except StopIteration:
-                    pass
-
-                if config_filename is None:
-                    continue
-                job_id = self.jobs.pop(config_filename)
+                job_id = None
                 try:
                     if settings.postgresql.objgraph_postgresql:
                         for generation in range(3):
@@ -753,13 +746,15 @@ class PostgresqlTileStore(AsyncTileStore):
                     async with self.SessionMaker() as session:
                         result = await session.execute(
                             select(Queue)
+                            .join(Job, Queue.job_id == Job.id)
                             .with_for_update(of=Queue, skip_locked=True)
-                            .order_by(Queue.id.asc())
-                            .where(and_(Queue.status == _STATUS_CREATED, Queue.job_id == job_id)),
+                            .order_by(Job.created_at.asc(), Queue.id.asc())
+                            .where(and_(Queue.status == _STATUS_CREATED, Job.status == _STATUS_STARTED)),
                         )
                         sqlalchemy_tile = result.scalar()
                         if sqlalchemy_tile is None:
                             continue
+                        job_id = sqlalchemy_tile.job_id
                         sqlalchemy_tile.status = _STATUS_PENDING
                         now = datetime.datetime.now(tz=datetime.UTC)
                         sqlalchemy_tile.started_at = now
@@ -779,10 +774,14 @@ class PostgresqlTileStore(AsyncTileStore):
                             postgresql_id=sqlalchemy_tile.id,
                         )
                         await session.commit()
+                    config_filename = next(
+                        (k for k, v in self.jobs.items() if v == job_id),
+                        None,
+                    )
                     yield meta_tile
                 except Exception:  # pylint: disable=broad-except
                     _LOGGER.exception("Error while reading from Postgres")
-                    _READ_ERROR_COUNTER.labels(job_id, config_filename).inc()
+                    _READ_ERROR_COUNTER.labels(job_id or -1, config_filename or "unknown").inc()
                     await asyncio.sleep(1)
 
     async def put_one(self, tile: Tile) -> Tile:

--- a/tilecloud_chain/tests/test_postgresql.py
+++ b/tilecloud_chain/tests/test_postgresql.py
@@ -363,3 +363,52 @@ async def test_controller_status_postgresql(SessionMaker: sessionmaker) -> None:
                 session.query(Job).filter(Job.id == job_id).delete()
                 session.commit()
         await gene.close()
+
+
+@pytest.mark.asyncio
+async def test_list_picks_next_job_when_first_job_has_only_pending_metatiles(
+    SessionMaker: sessionmaker,
+    tilestore: PostgresqlTileStore,
+):
+    """When a job has only pending meta-tiles, list() should pick from the next job."""
+    with SessionMaker() as session:
+        for job in session.query(Job).filter(Job.name.in_(["test-job-1", "test-job-2"])).all():
+            session.delete(job)
+        session.commit()
+
+    await tilestore.create_job("test-job-1", "generate-tiles", Path("config.yaml"))
+    await tilestore.create_job("test-job-2", "generate-tiles", Path("config.yaml"))
+
+    with SessionMaker() as session:
+        job1 = session.query(Job).filter(Job.name == "test-job-1").one()
+        job2 = session.query(Job).filter(Job.name == "test-job-2").one()
+        job1.status = _STATUS_STARTED
+        job2.status = _STATUS_STARTED
+        job1_id = job1.id
+        job2_id = job2.id
+        session.commit()
+
+    await tilestore.put_one(
+        Tile(TileCoord(0, 0, 0), metadata={"job_id": job1_id}),
+    )
+    await tilestore.put_one(
+        Tile(TileCoord(1, 0, 0), metadata={"job_id": job2_id}),
+    )
+    await tilestore.close()
+
+    with SessionMaker() as session:
+        session.query(Queue).filter(Queue.job_id == job1_id).update(
+            {Queue.status: _STATUS_PENDING},
+        )
+        session.commit()
+
+    await tilestore._maintenance()
+
+    tile = await anext(tilestore.list())
+    assert tile.tilecoord.z == 1
+    assert tile.metadata["job_id"] == job2_id
+
+    with SessionMaker() as session:
+        session.query(Queue).filter(Queue.job_id.in_([job1_id, job2_id])).delete()
+        session.query(Job).filter(Job.id.in_([job1_id, job2_id])).delete()
+        session.commit()


### PR DESCRIPTION
## Summary
When a PostgreSQL queue job has only pending meta-tiles (being processed by other workers), workers can now pick meta-tiles from any other started job instead of being blocked.

## Context
Previously, when a worker tried to get the next meta-tile from a job where all meta-tiles were already in pending status (being processed by other workers), the worker would loop without finding work. This caused inefficiency when multiple jobs were queued.

## Implementation Details
- Modified the list() method in PostgresqlTileStore to join Queue with Job and search for created meta-tiles across all started jobs
- Results are ordered by Job.created_at ASC, Queue.id ASC for fairness (older jobs first)
- The self.jobs dict is no longer popped; it only triggers maintenance when empty
- Added test test_list_picks_next_job_when_first_job_has_only_pending_metatiles to verify the behavior

## Impact/Risks
- No breaking changes
- Improves worker efficiency when multiple jobs are queued
- Workers are no longer blocked waiting for other workers to finish processing a job's meta-tiles