### PR TITLE
Add workflow-level permissions to GitHub Actions

### DIFF
--- a/.github/workflows/rebuild.yaml
+++ b/.github/workflows/rebuild.yaml
@@ -4,6 +4,9 @@ on:
   schedule:
     - cron: 30 2 * * *
 
+permissions:
+  contents: read
+
 jobs:
   rebuild:
     name: Rebuild


### PR DESCRIPTION
## Summary
Add top-level `permissions` to GitHub Actions workflows to enforce least-privilege permissions.

## Changes
- `pull-request-automation.yaml`: Added `permissions: contents: read`
- `rebuild.yaml`: Added `permissions: contents: read`