### PR TITLE
Remove unused gopass patterns

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -32,7 +32,6 @@ jobs:
         with:
           ci-gpg-private-key: ${{secrets.CI_GPG_PRIVATE_KEY}}
           github-gopass-ci-token: ${{secrets.GOPASS_CI_GITHUB_TOKEN}}
-          patterns: pypi docker
         if: env.HAS_SECRETS == 'HAS_SECRETS'
 
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -28,12 +28,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: camptocamp/initialise-gopass-summon-action@17703c87720ba3766abc90da60b437783b530d93 # v2.0.1
-        with:
-          ci-gpg-private-key: ${{secrets.CI_GPG_PRIVATE_KEY}}
-          github-gopass-ci-token: ${{secrets.GOPASS_CI_GITHUB_TOKEN}}
-        if: env.HAS_SECRETS == 'HAS_SECRETS'
-
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
       - run: python3 -m pip install --requirement=ci/requirements.txt
 

--- a/.github/workflows/rebuild.yaml
+++ b/.github/workflows/rebuild.yaml
@@ -28,10 +28,6 @@ jobs:
         with:
           ref: ${{ matrix.branch }}
 
-      - uses: camptocamp/initialise-gopass-summon-action@17703c87720ba3766abc90da60b437783b530d93 # v2.0.1
-        with:
-          ci-gpg-private-key: ${{secrets.CI_GPG_PRIVATE_KEY}}
-          github-gopass-ci-token: ${{secrets.GOPASS_CI_GITHUB_TOKEN}}
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: '3.14'

--- a/.github/workflows/rebuild.yaml
+++ b/.github/workflows/rebuild.yaml
@@ -32,8 +32,6 @@ jobs:
         with:
           ci-gpg-private-key: ${{secrets.CI_GPG_PRIVATE_KEY}}
           github-gopass-ci-token: ${{secrets.GOPASS_CI_GITHUB_TOKEN}}
-          patterns: pypi docker
-
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: '3.14'


### PR DESCRIPTION
tag-publish now handles PyPI authentication via OIDC trusted publishing and ghcr.io authentication via GITHUB_TOKEN. The gopass `pypi` and `docker` patterns in `initialise-gopass-summon-action` are therefore redundant.

This PR removes:
- `pypi` pattern (handled by tag-publish OIDC)
- `docker` pattern for repos publishing only to ghcr.io (handled by tag-publish GITHUB_TOKEN)

Repos publishing to Docker Hub explicitly (docker-mapserver, docker-qgis-server, docker-tinyows, mapfish-print) keep the `docker` pattern.
The `transifex` pattern is kept where applicable (c2cgeoportal, ngeo).