### PR TITLE
Remove unused gopass patterns

### DIFF
--- a/.github/workflows/rebuild.yaml
+++ b/.github/workflows/rebuild.yaml
@@ -28,6 +28,12 @@ jobs:
         with:
           ref: ${{ matrix.branch }}
 
+      - uses: camptocamp/initialise-gopass-summon-action@v2
+        with:
+          ci-gpg-private-key: ${{secrets.CI_GPG_PRIVATE_KEY}}
+          github-gopass-ci-token: ${{secrets.GOPASS_CI_GITHUB_TOKEN}}
+          patterns: docker
+
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: '3.14'

--- a/.github/workflows/rebuild.yaml
+++ b/.github/workflows/rebuild.yaml
@@ -32,7 +32,7 @@ jobs:
         with:
           ci-gpg-private-key: ${{secrets.CI_GPG_PRIVATE_KEY}}
           github-gopass-ci-token: ${{secrets.GOPASS_CI_GITHUB_TOKEN}}
-          patterns: docker
+          patterns: pypi docker
 
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:


### PR DESCRIPTION
`tag-publish` handles PyPI and ghcr.io authentication via OIDC, so the gopass `pypi` and `docker` patterns are unnecessary for those. However, `c2cciutils-publish` still requires Docker credentials for pushing to registries.

This PR removes unused patterns but keeps `docker` where `c2cciutils-publish` is used.