### PR TITLE
Fix jobs stuck in started state when queue is empty

### DIFF
--- a/tilecloud_chain/store/postgresql.py
+++ b/tilecloud_chain/store/postgresql.py
@@ -753,6 +753,7 @@ class PostgresqlTileStore(AsyncTileStore):
                         )
                         sqlalchemy_tile = result.scalar()
                         if sqlalchemy_tile is None:
+                            await self._maintenance()
                             continue
                         job_id = sqlalchemy_tile.job_id
                         sqlalchemy_tile.status = _STATUS_PENDING

--- a/tilecloud_chain/tests/test_postgresql.py
+++ b/tilecloud_chain/tests/test_postgresql.py
@@ -412,3 +412,46 @@ async def test_list_picks_next_job_when_first_job_has_only_pending_metatiles(
         session.query(Queue).filter(Queue.job_id.in_([job1_id, job2_id])).delete()
         session.query(Job).filter(Job.id.in_([job1_id, job2_id])).delete()
         session.commit()
+
+
+@pytest.mark.asyncio
+async def test_list_triggers_maintenance_when_no_tiles_available(
+    queue: tuple[int, int, int],
+    SessionMaker: sessionmaker,
+    tilestore: PostgresqlTileStore,
+):
+    """Test that list() triggers _maintenance() when no tiles are available, even if self.jobs is not empty.
+
+    This reproduces the scenario where workers have consumed all tiles from the queue
+    but the job remains in STARTED state because _maintenance() was never called
+    (since self.jobs was not empty).
+    """
+    import asyncio
+
+    job_id, _, _ = queue
+
+    tilestore.jobs["config.yaml"] = job_id
+
+    tile_1 = await anext(tilestore.list())
+    tile_2 = await anext(tilestore.list())
+
+    await tilestore.delete_one(tile_1)
+    await tilestore.delete_one(tile_2)
+
+    with SessionMaker() as session:
+        metatiles = session.query(Queue).filter(Queue.job_id == job_id).all()
+        assert len(metatiles) == 0
+
+    with SessionMaker() as session:
+        job = session.query(Job).filter(Job.id == job_id).one()
+        assert job.status == _STATUS_STARTED
+
+    list_iter = tilestore.list()
+    try:
+        await asyncio.wait_for(list_iter.__anext__(), timeout=2.0)
+    except asyncio.TimeoutError:
+        pass
+
+    with SessionMaker() as session:
+        job = session.query(Job).filter(Job.id == job_id).one()
+        assert job.status == _STATUS_DONE

--- a/tilecloud_chain/tests/test_postgresql.py
+++ b/tilecloud_chain/tests/test_postgresql.py
@@ -449,7 +449,7 @@ async def test_list_triggers_maintenance_when_no_tiles_available(
     list_iter = tilestore.list()
     try:
         await asyncio.wait_for(list_iter.__anext__(), timeout=2.0)
-    except asyncio.TimeoutError:
+    except TimeoutError:
         pass
 
     with SessionMaker() as session:


### PR DESCRIPTION
## Summary

Fix a bug where PostgreSQL-backed jobs remain in `started` state forever after all their tiles have been consumed by workers, instead of being transitioned to `done` or `error`.

## Context

Jobs were observed stuck in `started` state with zero queue entries. The `_maintenance()` method is the only code path that transitions `STARTED` jobs to `DONE`/`ERROR` (when the queue is empty), but it was only called from `list()` when `self.jobs` was empty. Once workers had jobs registered in `self.jobs`, `_maintenance()` was never called again, leaving completed jobs in `started` forever.

## Implementation Details

In `PostgresqlTileStore.list()`, when no tiles are available for consumption (`sqlalchemy_tile is None`), the loop now calls `_maintenance()` before continuing. This ensures the job status transition check runs even when `self.jobs` is not empty.

A test `test_list_triggers_maintenance_when_no_tiles_available` reproduces the exact scenario: a job with all tiles consumed but `self.jobs` populated, verifying that `list()` triggers the transition to `DONE`.

## Impact/Risks

Low risk. The change only adds a `_maintenance()` call in the idle path of the worker loop (when no tiles are available). The `_maintenance()` method already uses `skip_locked=True` to avoid conflicts between workers.