### PR TITLE
Optimize PostgreSQL initialization with timeout and conditional ALTER TABLE

### DIFF
--- a/tilecloud_chain/USAGE.rst
+++ b/tilecloud_chain/USAGE.rst
@@ -930,6 +930,9 @@ PostgreSQL:
 - ``TILECLOUD_CHAIN__POSTGRESQL__OBJGRAPH_LIMIT``: Number of entries to include in PostgreSQL objgraph reports
   (default: ``10``)
 
+- ``TILECLOUD_CHAIN__POSTGRESQL__INIT_TIMEOUT``: Timeout in seconds for PostgreSQL database initialization
+  (default: ``30``)
+
 See also: ``settings.py` <https://github.com/camptocamp/tilecloud-chain/blob/master/tilecloud_chain/settings.py>`_.
 
 Admin and test pages

--- a/tilecloud_chain/settings.py
+++ b/tilecloud_chain/settings.py
@@ -123,6 +123,7 @@ class PostgresqlSettings(BaseModel):
     queue_insert_batch_size: int = 100
     objgraph_postgresql: bool = False
     objgraph_limit: int = 10
+    init_timeout: int = 30
 
 
 class SecuritySettings(BaseModel):

--- a/tilecloud_chain/store/postgresql.py
+++ b/tilecloud_chain/store/postgresql.py
@@ -382,21 +382,44 @@ class PostgresqlTileStore(AsyncTileStore):
         """Initialize the store."""
         self._engine = create_async_engine(self.sqlalchemy_url)
 
-        async with self._engine.connect() as connection:
-            await connection.execute(sqlalchemy.schema.CreateSchema(_schema, if_not_exists=True))
-            await connection.run_sync(Base.metadata.create_all)
-            await connection.execute(
-                text(
-                    f'ALTER TABLE "{_schema}"."job" ADD COLUMN IF NOT EXISTS tiles_started_at TIMESTAMPTZ',
-                ),
+        async def _do_init() -> None:
+            assert self._engine is not None
+            async with self._engine.connect() as connection:
+                await connection.execute(sqlalchemy.schema.CreateSchema(_schema, if_not_exists=True))
+                await connection.run_sync(Base.metadata.create_all)
+
+                result = await connection.execute(
+                    text(
+                        "SELECT column_name FROM information_schema.columns "
+                        "WHERE table_schema = :schema AND table_name = 'job' "
+                        "AND column_name IN ('tiles_started_at', 'meta_tiles_total')",
+                    ).bindparams(schema=_schema),
+                )
+                existing_columns = {row[0] for row in result}
+
+                if "tiles_started_at" not in existing_columns:
+                    await connection.execute(
+                        text(
+                            f'ALTER TABLE "{_schema}"."job" ADD COLUMN tiles_started_at TIMESTAMPTZ',
+                        ),
+                    )
+                if "meta_tiles_total" not in existing_columns:
+                    await connection.execute(
+                        text(
+                            f'ALTER TABLE "{_schema}"."job" '
+                            "ADD COLUMN meta_tiles_total INTEGER NOT NULL DEFAULT 0",
+                        ),
+                    )
+                await connection.commit()
+
+        try:
+            await asyncio.wait_for(_do_init(), timeout=settings.postgresql.init_timeout)
+        except TimeoutError:
+            _LOGGER.warning(
+                "Database initialization timed out after %d seconds",
+                settings.postgresql.init_timeout,
             )
-            await connection.execute(
-                text(
-                    f'ALTER TABLE "{_schema}"."job" '
-                    "ADD COLUMN IF NOT EXISTS meta_tiles_total INTEGER NOT NULL DEFAULT 0",
-                ),
-            )
-            await connection.commit()
+            raise
 
         self.SessionMaker = async_sessionmaker(self._engine)  # pylint: disable=invalid-name
 


### PR DESCRIPTION
## Summary
Optimizes PostgreSQL store initialization by checking column existence before running ALTER TABLE and adding a configurable timeout.

## Context
The PostgreSQL store initialization was executing ALTER TABLE statements on every startup, even when the columns already existed. This adds unnecessary database operations and can cause delays if the database is slow to respond.

## Implementation Details
- Added `init_timeout` setting to `PostgresqlSettings` (default: 30 seconds)
- Query `information_schema.columns` to check which columns exist before running ALTER TABLE
- Only execute ALTER TABLE for missing columns (`tiles_started_at` and `meta_tiles_total`)
- Wrap initialization in `asyncio.wait_for` with configurable timeout
- Documented new `TILECLOUD_CHAIN__POSTGRESQL__INIT_TIMEOUT` environment variable in USAGE.rst

## Impact/Risks
- Backward compatible: existing databases will work as before
- New databases skip ALTER TABLE entirely (columns created by `Base.metadata.create_all`)
- Configurable timeout prevents hanging on slow/unresponsive databases