### PR TITLE
Fix reStructuredText syntax in USAGE.rst

### DIFF
--- a/tilecloud_chain/USAGE.rst
+++ b/tilecloud_chain/USAGE.rst
@@ -933,7 +933,7 @@ PostgreSQL:
 - ``TILECLOUD_CHAIN__POSTGRESQL__INIT_TIMEOUT``: Timeout in seconds for PostgreSQL database initialization
   (default: ``30``)
 
-See also: ``settings.py` <https://github.com/camptocamp/tilecloud-chain/blob/master/tilecloud_chain/settings.py>`_.
+See also: :file:`settings.py <https://github.com/camptocamp/tilecloud-chain/blob/master/tilecloud_chain/settings.py>`_.
 
 Admin and test pages
 --------------------


### PR DESCRIPTION
## Summary
Fix incorrect reStructuredText syntax for the settings.py link in USAGE.rst (line 936).

## Context
The link had a syntax error: double backticks at the start but single backtick at the end, causing a docutils warning:
`tilecloud_chain/USAGE.rst:936: WARNING: Inline literal start-string without end-string.`

## Implementation Details
Changed from ``settings.py` <url>`_ to :file:`settings.py <url>`_, using the reStructuredText `file` role to display the filename as code while keeping the link functional.