### PR TITLE
Use c2casgiutils route_prefix instead of tilecloud-chain's own

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.0.1
+
+- Replace `TILECLOUD_CHAIN__ROUTE_PREFIX` with `C2C__ROUTE_PREFIX` (from c2casgiutils) for the route prefix environment variable. The default remains `/tiles/` when using the Docker image.
+
 ## 2.0.0
 
 - Add a read-only mode to the admin interface: the configured `authentication.github_access_type` grants read-write access, while users with only a `pull` access on the configured `authentication.github_repository` can see the status and jobs but cannot start, cancel or retry generations.

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ RUN --mount=type=cache,target=/var/lib/apt/lists \
     && python3 -m venv --system-site-packages /venv
 
 ENV PATH=/venv/bin:$PATH
+ENV C2C__ROUTE_PREFIX=/tiles/
 
 # Used to convert the locked packages by poetry to pip requirements format
 # We don't directly use `poetry install` because it force to use a virtual environment.

--- a/tilecloud_chain/CONFIG.md
+++ b/tilecloud_chain/CONFIG.md
@@ -314,7 +314,7 @@
   - <a id="definitions/server/properties/geoms_redirect"></a>**`geoms_redirect`** *(boolean)*: Take care on the geometries. Default: `false`.
   - <a id="definitions/server/properties/static_allow_extension"></a>**`static_allow_extension`** *(array)*: The allowed extension of static files. Default: `["jpeg", "png", "xml", "js", "html", "css"]`.
     - <a id="definitions/server/properties/static_allow_extension/items"></a>**Items** *(string)*
-  - <a id="definitions/server/properties/wmts_path"></a>**`wmts_path`** *(string)*: No longer used, replaced by `TILECLOUD_CHAIN__ROUTE_PREFIX` or `TILECLOUD_CHAIN__WMTS_PATH` environment variable.
+  - <a id="definitions/server/properties/wmts_path"></a>**`wmts_path`** *(string)*: No longer used, replaced by `C2C__ROUTE_PREFIX` or `TILECLOUD_CHAIN__WMTS_PATH` environment variable.
   - <a id="definitions/server/properties/admin_path"></a>**`admin_path`** *(string)*: No longer used.
   - <a id="definitions/server/properties/static_path"></a>**`static_path`** *(string)*: No longer used.
   - <a id="definitions/server/properties/expires"></a>**`expires`** *(integer)*: The browser cache expiration in hours. Default: `8`.

--- a/tilecloud_chain/USAGE.rst
+++ b/tilecloud_chain/USAGE.rst
@@ -886,11 +886,11 @@ Server:
 - ``TILECLOUD_CHAIN__DEVELOPMENT``: Enable development features if set to ``true``
   (default: ``false``)
 
-- ``TILECLOUD_CHAIN__ROUTE_PREFIX``: Base URL path for tile access
-  (default: ``/tiles/``)
+- ``C2C__ROUTE_PREFIX``: Base URL path for tile access
+  (default: ``/tiles/``, provided by c2casgiutils)
 
 - ``TILECLOUD_CHAIN__WMTS_PATH``: Path used in WMTS capabilities URLs, overrides the route prefix
-  (default: the value of ``TILECLOUD_CHAIN__ROUTE_PREFIX`` without a leading ``/``)
+  (default: the value of ``C2C__ROUTE_PREFIX`` without a leading ``/``)
 
 Worker:
 

--- a/tilecloud_chain/configuration.py
+++ b/tilecloud_chain/configuration.py
@@ -2970,7 +2970,7 @@ class Server(TypedDict, total=False):
     r"""
     WMTS path.
 
-    No longer used, replaced by `TILECLOUD_CHAIN__ROUTE_PREFIX` or `TILECLOUD_CHAIN__WMTS_PATH` environment variable
+    No longer used, replaced by `C2C__ROUTE_PREFIX` or `TILECLOUD_CHAIN__WMTS_PATH` environment variable
     """
 
     admin_path: str

--- a/tilecloud_chain/main.py
+++ b/tilecloud_chain/main.py
@@ -110,7 +110,7 @@ app.add_middleware(
     allow_headers=settings.security.cors_headers,
 )
 
-route_prefix = settings.route_prefix
+route_prefix = c2c_settings.route_prefix
 route_prefix_escaped = re.escape(route_prefix[1:])
 
 _LOGGER.info("Using route prefix: '%s'", route_prefix)

--- a/tilecloud_chain/schema.json
+++ b/tilecloud_chain/schema.json
@@ -1188,7 +1188,7 @@
         },
         "wmts_path": {
           "title": "WMTS path",
-          "description": "No longer used, replaced by `TILECLOUD_CHAIN__ROUTE_PREFIX` or `TILECLOUD_CHAIN__WMTS_PATH` environment variable",
+          "description": "No longer used, replaced by `C2C__ROUTE_PREFIX` or `TILECLOUD_CHAIN__WMTS_PATH` environment variable",
           "type": "string"
         },
         "admin_path": {

--- a/tilecloud_chain/server.py
+++ b/tilecloud_chain/server.py
@@ -64,6 +64,7 @@ from tilecloud_chain import (
     internal_mapcache,
 )
 from tilecloud_chain.controller import validate_generate_wmts_capabilities
+from c2casgiutils.config import settings as c2c_settings
 from tilecloud_chain.settings import settings
 from tilecloud_chain.store import AsyncTileStore
 
@@ -522,7 +523,9 @@ class Server:
                     )
                 server_config = (await _TILEGENERATION.get_main_config()).config.get("server")
 
-                wmts_path = settings.route_prefix[1:] if settings.wmts_path is None else settings.wmts_path
+                wmts_path = (
+                    c2c_settings.route_prefix[1:] if settings.wmts_path is None else settings.wmts_path
+                )
 
                 base_urls = _get_base_urls(cache)
 
@@ -849,7 +852,7 @@ class Server:
 server = Server()
 router = fastapi.APIRouter()
 
-route_prefix = settings.route_prefix
+route_prefix = c2c_settings.route_prefix
 
 
 async def startup(_main_app: FastAPI) -> None:

--- a/tilecloud_chain/server.py
+++ b/tilecloud_chain/server.py
@@ -47,6 +47,7 @@ import html_sanitizer
 import yaml
 from anyio import Path
 from azure.core.exceptions import ResourceNotFoundError
+from c2casgiutils.config import settings as c2c_settings
 from fastapi import FastAPI, HTTPException, Query, Request
 from fastapi.responses import Response
 from fastapi.templating import Jinja2Templates
@@ -64,7 +65,6 @@ from tilecloud_chain import (
     internal_mapcache,
 )
 from tilecloud_chain.controller import validate_generate_wmts_capabilities
-from c2casgiutils.config import settings as c2c_settings
 from tilecloud_chain.settings import settings
 from tilecloud_chain.store import AsyncTileStore
 

--- a/tilecloud_chain/settings.py
+++ b/tilecloud_chain/settings.py
@@ -40,19 +40,6 @@ def _to_str_list(value: str | list[str] | None) -> list[str]:
 StrList = Annotated[list[str], BeforeValidator(_to_str_list)]
 
 
-def _to_route_prefix(route_prefix: str) -> str:
-    if not route_prefix:
-        return "/"
-    if not route_prefix.startswith("/"):
-        route_prefix = f"/{route_prefix}"
-    if not route_prefix.endswith("/"):
-        route_prefix = f"{route_prefix}/"
-    return route_prefix
-
-
-RoutePrefix = Annotated[str, BeforeValidator(_to_route_prefix)]
-
-
 def _to_wmts_path(wmts_path: str | None) -> str | None:
     if wmts_path is None:
         return None
@@ -154,7 +141,6 @@ class Settings(BaseSettings):
     allowed_process_commands: StrList = ["optipng", "jpegoptim", "pngquant"]
     frontend: str | None = None
     development: bool = False
-    route_prefix: RoutePrefix = "/tiles/"
     wmts_path: WmtsPath = None
 
     azure: AzureSettings = AzureSettings()

--- a/tilecloud_chain/views/admin.py
+++ b/tilecloud_chain/views/admin.py
@@ -271,7 +271,7 @@ async def admin_index(
         "current_url": str(request.url),
         "commands": server_config.get("predefined_commands", []),
         "status": await get_status(gene) if queue_store != "postgresql" else None,
-        "admin_path": f"{settings.route_prefix}admin",
+        "admin_path": f"{c2c_config.settings.route_prefix}admin",
         "AuthenticationType": auth.AuthenticationType,
         "jobs_status": jobs_status,
         "footer": main_server_config.get("admin_footer") if has_access else None,


### PR DESCRIPTION
## Summary
Replace tilecloud-chain's own `route_prefix` setting with the one provided by c2casgiutils (`C2C__ROUTE_PREFIX`), eliminating duplicated configuration and validation logic.

## Context
tilecloud-chain defined its own `route_prefix` setting (`TILECLOUD_CHAIN__ROUTE_PREFIX`, default `/tiles/`) with a custom validator, while c2casgiutils already provides an equivalent `route_prefix` setting (`C2C__ROUTE_PREFIX`, default `/`) with identical normalization logic. This PR removes the duplication.

## Implementation Details
- Removed `_to_route_prefix` validator, `RoutePrefix` type alias, and `route_prefix` field from `tilecloud_chain.settings.Settings`
- Updated all references (`main.py`, `server.py`, `views/admin.py`) to use `c2c_settings.route_prefix` from c2casgiutils
- Added `ENV C2C__ROUTE_PREFIX=/tiles/` in the Dockerfile `base-all` stage to preserve the `/tiles/` default for Docker-based deployments
- Updated `schema.json`, `USAGE.rst`, and `CHANGELOG.md` documentation
- Regenerated `configuration.py` and `CONFIG.md` via jsonschema-gentypes

## Impact/Risks
- **Breaking change**: the environment variable changes from `TILECLOUD_CHAIN__ROUTE_PREFIX` to `C2C__ROUTE_PREFIX`
- Users installing outside Docker will need to set `C2C__ROUTE_PREFIX=tiles` to maintain the previous default behavior
- Docker image users are unaffected (default remains `/tiles/`)