### PR TITLE
Add generated SETTINGS.md with environment variables documentation

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -51,6 +51,18 @@ jobs:
         env:
           GITHUB_EVENT: ${{ toJson(github) }}
 
+      - name: Settings documentation
+        run: make settings-doc
+      - run: git diff --exit-code --color
+      - run: git diff --patch > /tmp/settings-doc.patch; git reset --hard || true
+        if: failure()
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: Update settings documentation.patch
+          path: /tmp/settings-doc.patch
+          retention-days: 1
+        if: failure()
+
       - name: Build
         run: make build
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -53,6 +53,10 @@ repos:
       - id: prettier
         additional_dependencies:
           - prettier@2.8.4
+        exclude: |-
+          (?x)^(
+            tilecloud_chain/SETTINGS\.md
+          )$
   - repo: https://github.com/camptocamp/jsonschema-gentypes
     rev: 2.13.0
     hooks:

--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,16 @@ tests: build ## Run the unit tests
 
 PYTEST_ARGS ?= --last-failed --full-trace
 
+.PHONY: settings-doc
+settings-doc: ## Generate settings documentation
+	poetry install --no-root
+	PYTHONPATH=. poetry run settings-doc generate \
+		--class=tilecloud_chain.settings.Settings \
+		--output-format=markdown \
+		--update=tilecloud_chain/SETTINGS.md \
+		--between "<!-- generated env. vars. start -->" "<!-- generated env. vars. end -->" \
+		--heading-offset=1
+
 .PHONY: tests-fast
 tests-fast:
 	docker compose up -d

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ make tests
 
 - [Usage Guide](https://github.com/camptocamp/tilecloud-chain/blob/master/tilecloud_chain/USAGE.rst)
 - [Configuration Reference](https://github.com/camptocamp/tilecloud-chain/blob/master/tilecloud_chain/CONFIG.md)
-- [Environment variables](https://github.com/camptocamp/tilecloud-chain/blob/master/tilecloud_chain/settings.py)
+- [Environment variables](https://github.com/camptocamp/tilecloud-chain/blob/master/tilecloud_chain/SETTINGS.md)
 
 ## Contributing
 

--- a/ci/requirements.txt
+++ b/ci/requirements.txt
@@ -1,3 +1,4 @@
+poetry==2.4.1
 c2cciutils==1.7.5
 poetry-plugin-export==1.10.0
 pre-commit==4.6.2

--- a/poetry.lock
+++ b/poetry.lock
@@ -260,7 +260,7 @@ version = "0.8.0"
 description = "Reusable constraint types to use with typing.Annotated"
 optional = false
 python-versions = ">=3.10"
-groups = ["main"]
+groups = ["main", "dev"]
 files = [
     {file = "annotated_types-0.8.0-py3-none-any.whl", hash = "sha256:f072f4d804ea359e4eaf198b1af7a8b0943881a87f31bb764f8bf219bb9419e0"},
     {file = "annotated_types-0.8.0.tar.gz", hash = "sha256:13b2beaad985e05e2d6407ee4c4f35590b11f8d693a258a561055cac8f64cab7"},
@@ -1086,7 +1086,7 @@ version = "8.4.2"
 description = "Composable command line interface toolkit"
 optional = false
 python-versions = ">=3.10"
-groups = ["main"]
+groups = ["main", "dev"]
 files = [
     {file = "click-8.4.2-py3-none-any.whl", hash = "sha256:e6f9f66136c816745b9d65817da91d61d957fb16e02e4dcd0552553c5a197b76"},
     {file = "click-8.4.2.tar.gz", hash = "sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6"},
@@ -1825,7 +1825,6 @@ description = "Lightweight in-process concurrent programming"
 optional = false
 python-versions = ">=3.10"
 groups = ["main"]
-markers = "platform_machine == \"aarch64\" or platform_machine == \"ppc64le\" or platform_machine == \"x86_64\" or platform_machine == \"amd64\" or platform_machine == \"AMD64\" or platform_machine == \"win32\" or platform_machine == \"WIN32\""
 files = [
     {file = "greenlet-3.5.5-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:816230f469381ad0a43abc9fa8dda5a699e32fb78958dde32ded93213b70a667"},
     {file = "greenlet-3.5.5-cp310-cp310-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a5433cf291e0ef9114bd14d0d824db6e5e4a43033234bca48181a9597acca07b"},
@@ -2181,7 +2180,7 @@ version = "3.1.6"
 description = "A very fast and expressive template engine."
 optional = false
 python-versions = ">=3.7"
-groups = ["main"]
+groups = ["main", "dev"]
 files = [
     {file = "jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67"},
     {file = "jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d"},
@@ -2689,7 +2688,7 @@ version = "3.0.3"
 description = "Safely add untrusted strings to HTML/XML markup."
 optional = false
 python-versions = ">=3.9"
-groups = ["main"]
+groups = ["main", "dev"]
 files = [
     {file = "markupsafe-3.0.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:2f981d352f04553a7171b8e44369f2af4055f888dfb147d55e42d29e29e74559"},
     {file = "markupsafe-3.0.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:e1c1493fb6e50ab01d20a22826e57520f1284df32f2d8601fdd90b6304601419"},
@@ -3906,7 +3905,7 @@ version = "2.13.4"
 description = "Data validation using Python type hints"
 optional = false
 python-versions = ">=3.9"
-groups = ["main"]
+groups = ["main", "dev"]
 files = [
     {file = "pydantic-2.13.4-py3-none-any.whl", hash = "sha256:45a282cde31d808236fd7ea9d919b128653c8b38b393d1c4ab335c62924d9aba"},
     {file = "pydantic-2.13.4.tar.gz", hash = "sha256:c40756b57adaa8b1efeeced5c196f3f3b7c435f90e84ea7f443901bec8099ef6"},
@@ -3929,7 +3928,7 @@ version = "2.46.4"
 description = "Core functionality for Pydantic validation and serialization"
 optional = false
 python-versions = ">=3.9"
-groups = ["main"]
+groups = ["main", "dev"]
 files = [
     {file = "pydantic_core-2.46.4-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:a396dcc17e5a0b164dbe026896245a4fa9ff402edca1dff0be3d53a517f74de4"},
     {file = "pydantic_core-2.46.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:da4b951fe36dc7c3a1ccb4e3cd1747c3542b8c9ceede8fc86cae054e764485f5"},
@@ -4088,7 +4087,7 @@ version = "2.15.0"
 description = "Settings management using Pydantic"
 optional = false
 python-versions = ">=3.10"
-groups = ["main"]
+groups = ["main", "dev"]
 files = [
     {file = "pydantic_settings-2.15.0-py3-none-any.whl", hash = "sha256:0ba092c291c94baceb5eff768aa0d56400a457585bc0175925a5a5510303da42"},
     {file = "pydantic_settings-2.15.0.tar.gz", hash = "sha256:694b793e84f766ba76a90ebdefc01d0a9a045dab0382bee70393da93712ad117"},
@@ -4493,7 +4492,7 @@ version = "1.2.2"
 description = "Read key-value pairs from a .env file and set them as environment variables"
 optional = false
 python-versions = ">=3.10"
-groups = ["main"]
+groups = ["main", "dev"]
 files = [
     {file = "python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a"},
     {file = "python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3"},
@@ -5330,6 +5329,24 @@ files = [
 yaml = ["pyyaml"]
 
 [[package]]
+name = "settings-doc"
+version = "4.3.2"
+description = "A command line tool for generating Markdown documentation and .env files from pydantic BaseSettings."
+optional = false
+python-versions = "<4.0.0,>=3.8.1"
+groups = ["dev"]
+files = [
+    {file = "settings_doc-4.3.2-py3-none-any.whl", hash = "sha256:04b561093905cab8f5ebaa30c9dacca1d57cd1dc3dd404b7c929b90e2d2d7c0b"},
+    {file = "settings_doc-4.3.2.tar.gz", hash = "sha256:cb06aee969f0639abc88e77554a333803191de95e95259a11929cf878d312fab"},
+]
+
+[package.dependencies]
+click = ">=8.0,<9.0"
+Jinja2 = ">=3.0.2,<4.0.0"
+pydantic = ">=2.3,<3.0"
+pydantic-settings = ">=2.0.3,<3.0.0"
+
+[[package]]
 name = "setuptools"
 version = "81.0.0"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
@@ -5899,7 +5916,7 @@ version = "0.4.4"
 description = "Runtime typing introspection tools"
 optional = false
 python-versions = ">=3.10"
-groups = ["main"]
+groups = ["main", "dev"]
 files = [
     {file = "typing_inspection-0.4.4-py3-none-any.whl", hash = "sha256:65b8397ba37ccbce054456aaccddfc91e6e3083c92824df348d96ca832f3f147"},
     {file = "typing_inspection-0.4.4.tar.gz", hash = "sha256:547274fa6b0a561ccf549cc9524b999a578e737d015d8709d021f9d0d13bea47"},
@@ -6726,4 +6743,4 @@ test = ["zope.testing"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<3.15"
-content-hash = "c932745ce95e1af2c2126e2a7d94d27957228721d0fd36e4e9ca1fc5fe00db30"
+content-hash = "3d102fa53b46085a2f4211ac915fa117531fb22d887458b6c6af3bb6d7723fd9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,7 @@ pytest-check = "2.9.1"
 types-pyyaml = "6.0.12.20260724"
 ruff = "0.16.2"
 pylint = "4.0.7"
+settings-doc = "4.3.2"
 
 [tool.poetry-dynamic-versioning]
 enable = true

--- a/tilecloud_chain/SETTINGS.md
+++ b/tilecloud_chain/SETTINGS.md
@@ -1,0 +1,231 @@
+# Environment variables
+
+<!-- generated env. vars. start -->
+## `TILECLOUD_CHAIN__MAX_OUTPUT_LENGTH`
+
+*Optional*, default value: `1000`
+
+## `TILECLOUD_CHAIN__NB_TASKS`
+
+*Optional*, default value: `1`
+
+## `TILECLOUD_CHAIN__SLAVE`
+
+*Optional*, default value: `False`
+
+## `TILECLOUD_CHAIN__OBJGRAPH_LIMIT`
+
+*Optional*, default value: `10`
+
+## `TILECLOUD_CHAIN__OBJGRAPH_GENE`
+
+*Optional*, default value: `False`
+
+## `TILECLOUD_CHAIN__CONFIG_FILE`
+
+*Optional*, default value: `/etc/tilegeneration/config.yaml`
+
+## `TILECLOUD_CHAIN__MAIN_CONFIG_FILE`
+
+*Optional*, default value: `None`
+
+## `TILECLOUD_CHAIN__HOSTS_FILE`
+
+*Optional*, default value: `/etc/tilegeneration/hosts.yaml`
+
+## `TILECLOUD_CHAIN__HOSTS_LIMIT`
+
+*Optional*, default value: `/etc/tilegeneration/hosts_limit.yaml`
+
+## `TILECLOUD_CHAIN__HOST_CONCURRENT`
+
+*Optional*, default value: `1`
+
+## `TILECLOUD_CHAIN__IGNORE_CONFIG_ERROR`
+
+*Optional*, default value: `False`
+
+## `TILECLOUD_CHAIN__MAX_GENERATION_TIME`
+
+*Optional*, default value: `60`
+
+## `TILECLOUD_CHAIN__ALLOWED_PROCESS_COMMANDS`
+
+*Optional*, default value: `['optipng', 'jpegoptim', 'pngquant']`
+
+## `TILECLOUD_CHAIN__FRONTEND`
+
+*Optional*, default value: `None`
+
+## `TILECLOUD_CHAIN__DEVELOPMENT`
+
+*Optional*, default value: `False`
+
+## `TILECLOUD_CHAIN__WMTS_PATH`
+
+*Optional*, default value: `None`
+
+## `TILECLOUD_CHAIN__AZURE__STORAGE_CONNECTION_STRING`
+
+*Optional*, default value: `None`
+
+## `TILECLOUD_CHAIN__AZURE__STORAGE_BLOB_CONTAINER_URL`
+
+*Optional*, default value: `None`
+
+## `TILECLOUD_CHAIN__AZURE__STORAGE_BLOB_VALIDATE_CONTAINER_NAME`
+
+*Optional*, default value: `True`
+
+## `TILECLOUD_CHAIN__AZURE__STORAGE_ACCOUNT_URL`
+
+*Optional*, default value: `None`
+
+## `TILECLOUD_CHAIN__LOGGING__CI`
+
+*Optional*, default value: `False`
+
+## `TILECLOUD_CHAIN__LOGGING__LOG_TYPE`
+
+*Optional*, default value: `console`
+
+## `TILECLOUD_CHAIN__LOGGING__OTHER_LOG_LEVEL`
+
+*Optional*, default value: `WARN`
+
+### Possible values
+
+`CRITICAL`, `ERROR`, `WARN`, `WARNING`, `INFO`, `DEBUG`, `NOTSET`
+
+## `TILECLOUD_CHAIN__LOGGING__SQL_LOG_LEVEL`
+
+*Optional*, default value: `WARN`
+
+### Possible values
+
+`CRITICAL`, `ERROR`, `WARN`, `WARNING`, `INFO`, `DEBUG`, `NOTSET`
+
+## `TILECLOUD_CHAIN__LOGGING__C2CASGIUTILS_LOG_LEVEL`
+
+*Optional*, default value: `WARN`
+
+### Possible values
+
+`CRITICAL`, `ERROR`, `WARN`, `WARNING`, `INFO`, `DEBUG`, `NOTSET`
+
+## `TILECLOUD_CHAIN__LOGGING__TILECLOUD_LOG_LEVEL`
+
+*Optional*, default value: `INFO`
+
+### Possible values
+
+`CRITICAL`, `ERROR`, `WARN`, `WARNING`, `INFO`, `DEBUG`, `NOTSET`
+
+## `TILECLOUD_CHAIN__LOGGING__TILECLOUD_CHAIN_LOG_LEVEL`
+
+*Optional*, default value: `INFO`
+
+### Possible values
+
+`CRITICAL`, `ERROR`, `WARN`, `WARNING`, `INFO`, `DEBUG`, `NOTSET`
+
+## `TILECLOUD_CHAIN__LOGGING__SERVER_LOG_LEVEL`
+
+*Optional*, default value: `quiet`
+
+### Possible values
+
+`quiet`, `verbose`, `debug`
+
+## `TILECLOUD_CHAIN__LOGGING__MAPCACHE_LOG_LEVEL`
+
+*Optional*, default value: `verbose`
+
+### Possible values
+
+`quiet`, `verbose`, `debug`
+
+## `TILECLOUD_CHAIN__POSTGRESQL__SCHEMA_NAME`
+
+*Optional*, default value: `tilecloud_chain`
+
+## `TILECLOUD_CHAIN__POSTGRESQL__SQLALCHEMY_URL`
+
+*Optional*, default value: `None`
+
+## `TILECLOUD_CHAIN__POSTGRESQL__QUEUE_INSERT_BATCH_SIZE`
+
+*Optional*, default value: `100`
+
+## `TILECLOUD_CHAIN__POSTGRESQL__OBJGRAPH_POSTGRESQL`
+
+*Optional*, default value: `False`
+
+## `TILECLOUD_CHAIN__POSTGRESQL__OBJGRAPH_LIMIT`
+
+*Optional*, default value: `10`
+
+## `TILECLOUD_CHAIN__POSTGRESQL__INIT_TIMEOUT`
+
+*Optional*, default value: `30`
+
+## `TILECLOUD_CHAIN__REDIS__URL`
+
+*Optional*, default value: `None`
+
+## `TILECLOUD_CHAIN__REDIS__DB`
+
+*Optional*, default value: `None`
+
+## `TILECLOUD_CHAIN__REDIS__SOCKET_TIMEOUT`
+
+*Optional*, default value: `None`
+
+## `TILECLOUD_CHAIN__REDIS__SENTINELS`
+
+*Optional*, default value: `None`
+
+## `TILECLOUD_CHAIN__REDIS__SERVICE_NAME`
+
+*Optional*, default value: `None`
+
+## `TILECLOUD_CHAIN__REDIS__OPTIONS`
+
+*Optional*, default value: `None`
+
+## `TILECLOUD_CHAIN__REDIS__QUEUE`
+
+*Optional*, default value: `None`
+
+## `TILECLOUD_CHAIN__REDIS__TIMEOUT`
+
+*Optional*, default value: `None`
+
+## `TILECLOUD_CHAIN__REDIS__SENTINEL_SERVICE_NAME`
+
+*Optional*, default value: `None`
+
+## `TILECLOUD_CHAIN__TESTS`
+
+*Optional*, default value: `False`
+
+## `TILECLOUD_CHAIN__SECURITY__TRUSTED_HOSTS`
+
+*Optional*, default value: `['*']`
+
+## `TILECLOUD_CHAIN__SECURITY__CORS_ORIGINS`
+
+*Optional*, default value: `['*']`
+
+## `TILECLOUD_CHAIN__SECURITY__CORS_METHODS`
+
+*Optional*, default value: `['*']`
+
+## `TILECLOUD_CHAIN__SECURITY__CORS_HEADERS`
+
+*Optional*, default value: `['*']`
+
+## `TILECLOUD_CHAIN__SECURITY__CORS_CREDENTIALS`
+
+*Optional*, default value: `True`
+<!-- generated env. vars. end -->


### PR DESCRIPTION
## Summary
Generate and maintain `tilecloud_chain/SETTINGS.md` automatically from the `Settings` pydantic class using `settings-doc`. The CI verifies the documentation stays up to date and provides a downloadable patch on failure.

## Context
Environment variables were only documented by linking to `settings.py` source code. This makes it hard for users to discover available configuration options. Following the pattern established in [c2casgiutils](https://github.com/camptocamp/c2casgiutils/blob/29fb7464a4b8ab95343796b5a2f463f2853c6cdb/Makefile#L29-L34), this PR introduces automatic generation of a dedicated SETTINGS.md file.

## Implementation Details
- Add `settings-doc 4.3.2` to dev dependencies (`pyproject.toml`)
- Add `poetry` to `ci/requirements.txt` so the CI can run `poetry run settings-doc`
- Add `settings-doc` Makefile target using `--between` markers and `--heading-offset=1` to preserve a manual title section
- Add CI steps in `.github/workflows/main.yaml`: regenerate, `git diff --exit-code` check, and upload patch artifact on failure
- Update `README.md` documentation link from `settings.py` to `SETTINGS.md`
- Generate initial `tilecloud_chain/SETTINGS.md` with all 42 environment variables documented

## Impact/Risks
- No breaking changes; purely additive documentation
- CI will fail if SETTINGS.md is not regenerated after modifying `settings.py`, with a downloadable patch to fix it