### PR TITLE
Fix reStructuredText syntax in USAGE.rst for settings.py link

### DIFF
--- a/tilecloud_chain/USAGE.rst
+++ b/tilecloud_chain/USAGE.rst
@@ -933,7 +933,7 @@ PostgreSQL:
 - ``TILECLOUD_CHAIN__POSTGRESQL__INIT_TIMEOUT``: Timeout in seconds for PostgreSQL database initialization
   (default: ``30``)
 
-See also: :file:`settings.py <https://github.com/camptocamp/tilecloud-chain/blob/master/tilecloud_chain/settings.py>`_.
+See also: `settings.py <https://github.com/camptocamp/tilecloud-chain/blob/master/tilecloud_chain/settings.py>`_.
 
 Admin and test pages
 --------------------


### PR DESCRIPTION
The previous fix (2.0.1, commit b494f503) replaced the original invalid RST format (mismatched backticks) with `:file:`...`_` which mixes an interpreted text role prefix with a reference suffix, producing a new Sphinx warning: `Mismatch: both interpreted text role prefix and reference suffix`.

Fix: use a plain external hyperlink reference instead.