### PR TITLE
Fix RST mismatch warning in USAGE.rst

### DIFF
--- a/tilecloud_chain/USAGE.rst
+++ b/tilecloud_chain/USAGE.rst
@@ -933,7 +933,7 @@ PostgreSQL:
 - ``TILECLOUD_CHAIN__POSTGRESQL__INIT_TIMEOUT``: Timeout in seconds for PostgreSQL database initialization
   (default: ``30``)
 
-See also: :file:`settings\.py <https://github.com/camptocamp/tilecloud-chain/blob/master/tilecloud_chain/settings.py>`_.
+See also: `settings\.py <https://github.com/camptocamp/tilecloud-chain/blob/master/tilecloud_chain/settings.py>`_.
 
 Admin and test pages
 --------------------


### PR DESCRIPTION
## Summary
Replace the invalid RST syntax combining the `:file:` role with a hyperlink reference suffix (`_`), which causes a docutils warning: `Mismatch: both interpreted text role prefix and reference suffix`.

## Context
The `:file:` interpreted text role cannot be combined with a named hyperlink reference suffix in RST. The fix uses a standard anonymous hyperlink instead, which provides a clickable link with the filename as display text.

## Implementation Details
- Replaced `:file:` + `_` with standard anonymous hyperlink syntax (`text <url>`__)
- Verified with `docutils` that the warning is resolved

## Impact/Risks
- Documentation-only change, no functional impact