### PR TITLE
Use c2casgiutils Duration type for duration-based environment settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 2.0.1
 
+- Use the c2casgiutils `Duration` type for the `TILECLOUD_CHAIN__MAX_GENERATION_TIME`, `TILECLOUD_CHAIN__POSTGRESQL__INIT_TIMEOUT`, `TILECLOUD_CHAIN__REDIS__TIMEOUT` and `TILECLOUD_CHAIN__REDIS__SOCKET_TIMEOUT` environment variables. Values now also accept ISO 8601 durations (e.g. `PT1M`) and the short format (e.g. `1m`, `2m30`); plain numbers remain interpreted as seconds.
 - Replace `TILECLOUD_CHAIN__ROUTE_PREFIX` with `C2C__ROUTE_PREFIX` (from c2casgiutils) for the route prefix environment variable. The default remains `/tiles/` when using the Docker image.
 
 ## 2.0.0

--- a/tilecloud_chain/SETTINGS.md
+++ b/tilecloud_chain/SETTINGS.md
@@ -47,7 +47,7 @@
 
 ## `TILECLOUD_CHAIN__MAX_GENERATION_TIME`
 
-*Optional*, default value: `60`
+*Optional*, default value: `0:01:00`
 
 ## `TILECLOUD_CHAIN__ALLOWED_PROCESS_COMMANDS`
 
@@ -167,7 +167,7 @@
 
 ## `TILECLOUD_CHAIN__POSTGRESQL__INIT_TIMEOUT`
 
-*Optional*, default value: `30`
+*Optional*, default value: `0:00:30`
 
 ## `TILECLOUD_CHAIN__REDIS__URL`
 

--- a/tilecloud_chain/USAGE.rst
+++ b/tilecloud_chain/USAGE.rst
@@ -843,7 +843,8 @@ Tile generation:
 - ``TILECLOUD_CHAIN__IGNORE_CONFIG_ERROR``: Ignore configuration errors if set to ``true``
   (default: ``false``)
 
-- ``TILECLOUD_CHAIN__MAX_GENERATION_TIME``: Maximum tile generation time in seconds before timeout
+- ``TILECLOUD_CHAIN__MAX_GENERATION_TIME``: Maximum tile generation time before timeout, accepts ISO 8601
+  durations (e.g.: ``PT1M``), short format (e.g.: ``60s``, ``1m``) or seconds (e.g.: ``60``)
   (default: ``60``)
 
 - ``TILECLOUD_CHAIN__ALLOWED_PROCESS_COMMANDS``: Comma-separated list of allowed process commands
@@ -930,8 +931,19 @@ PostgreSQL:
 - ``TILECLOUD_CHAIN__POSTGRESQL__OBJGRAPH_LIMIT``: Number of entries to include in PostgreSQL objgraph reports
   (default: ``10``)
 
-- ``TILECLOUD_CHAIN__POSTGRESQL__INIT_TIMEOUT``: Timeout in seconds for PostgreSQL database initialization
+- ``TILECLOUD_CHAIN__POSTGRESQL__INIT_TIMEOUT``: Timeout for PostgreSQL database initialization, accepts
+  ISO 8601 durations (e.g.: ``PT30S``), short format (e.g.: ``30s``, ``1m``) or seconds (e.g.: ``30``)
   (default: ``30``)
+
+Redis:
+
+- ``TILECLOUD_CHAIN__REDIS__TIMEOUT``: Timeout used when waiting for messages from the Redis queue, accepts
+  ISO 8601 durations (e.g.: ``PT5S``), short format (e.g.: ``5s``, ``1m``) or seconds (e.g.: ``5``)
+  (default: ``None``, the ``redis.timeout`` of the main configuration is used, ``5`` by default)
+
+- ``TILECLOUD_CHAIN__REDIS__SOCKET_TIMEOUT``: Redis socket timeout, accepts ISO 8601 durations (e.g.: ``PT30S``),
+  short format (e.g.: ``30s``, ``1m``) or seconds (e.g.: ``30``)
+  (default: ``None``, the ``redis.socket_timeout`` of the main configuration is used)
 
 See also: `settings\.py <https://github.com/camptocamp/tilecloud-chain/blob/master/tilecloud_chain/settings.py>`_.
 

--- a/tilecloud_chain/__init__.py
+++ b/tilecloud_chain/__init__.py
@@ -2915,7 +2915,11 @@ async def get_queue_store(config: DatedConfig, daemon: bool) -> TimedTileStoreWr
         tilestore_kwargs: dict[str, Any] = {
             "name": settings.redis.queue or conf.get("queue", configuration.REDIS_QUEUE_DEFAULT),
             "stop_if_empty": not daemon,
-            "timeout": settings.redis.timeout or conf.get("timeout", configuration.TIMEOUT_DEFAULT),
+            "timeout": (
+                settings.redis.timeout.total_seconds()
+                if settings.redis.timeout is not None
+                else conf.get("timeout", configuration.TIMEOUT_DEFAULT)
+            ),
             "pending_timeout": conf.get("pending_timeout", configuration.PENDING_TIMEOUT_DEFAULT),
             "max_retries": conf.get("max_retries", configuration.MAX_RETRIES_DEFAULT),
             "max_errors_age": conf.get("max_errors_age", configuration.MAX_ERRORS_AGE_DEFAULT),
@@ -2925,7 +2929,11 @@ async def get_queue_store(config: DatedConfig, daemon: bool) -> TimedTileStoreWr
         }
         socket_timeout = settings.redis.socket_timeout or conf.get("socket_timeout")
         if socket_timeout is not None:
-            tilestore_kwargs["connection_kwargs"]["socket_timeout"] = socket_timeout
+            tilestore_kwargs["connection_kwargs"]["socket_timeout"] = (
+                socket_timeout.total_seconds()
+                if isinstance(socket_timeout, datetime.timedelta)
+                else int(socket_timeout)
+            )
         db = settings.redis.db or conf.get("db")
         if db is not None:
             tilestore_kwargs["connection_kwargs"]["db"] = db

--- a/tilecloud_chain/internal_mapcache.py
+++ b/tilecloud_chain/internal_mapcache.py
@@ -64,9 +64,13 @@ class RedisStore(AsyncTileStore):
             for key, value in [e.split("=", 1) for e in redis_options.split(",") if "=" in e]
         }
 
-        socket_timeout = settings.redis.socket_timeout or cast("str", config.get("socket_timeout"))
+        socket_timeout = settings.redis.socket_timeout or config.get("socket_timeout")
         if socket_timeout is not None:
-            connection_kwargs["socket_timeout"] = int(socket_timeout)
+            connection_kwargs["socket_timeout"] = (
+                socket_timeout.total_seconds()
+                if isinstance(socket_timeout, datetime.timedelta)
+                else int(socket_timeout)
+            )
         db = settings.redis.db or cast("str", config.get("db"))
         if db is not None:
             connection_kwargs["db"] = int(db)
@@ -136,7 +140,7 @@ class RedisStore(AsyncTileStore):
     async def lock(self, tile: Tile) -> AsyncIterator[None]:
         """Lock a tile."""
         key = self._get_key(tile) + "_l"
-        async with self._master.lock(key, timeout=_MAX_GENERATION_TIME):
+        async with self._master.lock(key, timeout=_MAX_GENERATION_TIME.total_seconds()):
             yield
 
     async def __contains__(self, tile: Tile) -> bool:

--- a/tilecloud_chain/settings.py
+++ b/tilecloud_chain/settings.py
@@ -3,9 +3,11 @@
 
 from __future__ import annotations
 
+import datetime
 from typing import Annotated, Literal
 
 from anyio import Path
+from c2casgiutils.config import Duration, parse_duration
 from pydantic import BaseModel, ConfigDict
 from pydantic.functional_validators import BeforeValidator
 from pydantic_settings import BaseSettings, SettingsConfigDict
@@ -53,6 +55,15 @@ def _to_wmts_path(wmts_path: str | None) -> str | None:
 WmtsPath = Annotated[str | None, BeforeValidator(_to_wmts_path)]
 
 
+def _to_optional_duration(value: str | datetime.timedelta | None) -> datetime.timedelta | None:
+    if value is None or value == "":
+        return None
+    return parse_duration(value)
+
+
+OptionalDuration = Annotated[datetime.timedelta | None, BeforeValidator(_to_optional_duration)]
+
+
 class AzureSettings(BaseModel):
     """Azure storage settings."""
 
@@ -91,12 +102,12 @@ class RedisSettings(BaseModel):
 
     url: str | None = None
     db: str | None = None
-    socket_timeout: str | None = None
+    socket_timeout: OptionalDuration = None
     sentinels: str | None = None
     service_name: str | None = None
     options: str | None = None
     queue: str | None = None
-    timeout: str | None = None
+    timeout: OptionalDuration = None
     sentinel_service_name: str | None = None
 
 
@@ -110,7 +121,7 @@ class PostgresqlSettings(BaseModel):
     queue_insert_batch_size: int = 100
     objgraph_postgresql: bool = False
     objgraph_limit: int = 10
-    init_timeout: int = 30
+    init_timeout: Duration = datetime.timedelta(seconds=30)
 
 
 class SecuritySettings(BaseModel):
@@ -137,7 +148,7 @@ class Settings(BaseSettings):
     hosts_limit: AnyioPath = Path("/etc/tilegeneration/hosts_limit.yaml")
     host_concurrent: int = 1
     ignore_config_error: bool = False
-    max_generation_time: int = 60
+    max_generation_time: Duration = datetime.timedelta(seconds=60)
     allowed_process_commands: StrList = ["optipng", "jpegoptim", "pngquant"]
     frontend: str | None = None
     development: bool = False

--- a/tilecloud_chain/store/postgresql.py
+++ b/tilecloud_chain/store/postgresql.py
@@ -418,11 +418,11 @@ class PostgresqlTileStore(AsyncTileStore):
                 await connection.commit()
 
         try:
-            await asyncio.wait_for(_do_init(), timeout=settings.postgresql.init_timeout)
+            await asyncio.wait_for(_do_init(), timeout=settings.postgresql.init_timeout.total_seconds())
         except TimeoutError:
             _LOGGER.warning(
                 "Database initialization timed out after %d seconds",
-                settings.postgresql.init_timeout,
+                int(settings.postgresql.init_timeout.total_seconds()),
             )
             raise
 

--- a/tilecloud_chain/tests/test_settings.py
+++ b/tilecloud_chain/tests/test_settings.py
@@ -1,0 +1,76 @@
+# Copyright (c) 2026 by Camptocamp
+"""Tests for the application settings."""
+
+import datetime
+
+import pytest
+from pydantic import ValidationError
+
+from tilecloud_chain.settings import PostgresqlSettings, RedisSettings, Settings
+
+
+class TestDurationSettings:
+    """Tests for the duration typed settings."""
+
+    def test_defaults(self) -> None:
+        """Test the default duration values."""
+        assert Settings.model_fields["max_generation_time"].default == datetime.timedelta(seconds=60)
+        assert PostgresqlSettings.model_fields["init_timeout"].default == datetime.timedelta(seconds=30)
+
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [
+            ("60", datetime.timedelta(seconds=60)),
+            ("2m", datetime.timedelta(minutes=2)),
+            ("2m30", datetime.timedelta(minutes=2, seconds=30)),
+            ("1h", datetime.timedelta(hours=1)),
+            ("PT1M30S", datetime.timedelta(minutes=1, seconds=30)),
+            (datetime.timedelta(minutes=5), datetime.timedelta(minutes=5)),
+        ],
+    )
+    def test_max_generation_time_parsing(self, value: object, expected: datetime.timedelta) -> None:
+        """Test that max_generation_time accepts durations in the supported formats."""
+        assert Settings(max_generation_time=value).max_generation_time == expected
+
+    def test_max_generation_time_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Test that max_generation_time is parsed from the environment variable."""
+        monkeypatch.setenv("TILECLOUD_CHAIN__MAX_GENERATION_TIME", "2m")
+        assert Settings().max_generation_time == datetime.timedelta(minutes=2)
+
+    def test_invalid_duration(self) -> None:
+        """Test that an invalid duration is rejected."""
+        with pytest.raises(ValidationError):
+            Settings(max_generation_time="not-a-duration")
+
+    def test_init_timeout_parsing(self) -> None:
+        """Test that init_timeout accepts durations in the supported formats."""
+        assert PostgresqlSettings(init_timeout="1m30").init_timeout == datetime.timedelta(
+            minutes=1,
+            seconds=30,
+        )
+
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [
+            (None, None),
+            ("", None),
+            ("30", datetime.timedelta(seconds=30)),
+            ("2m30", datetime.timedelta(minutes=2, seconds=30)),
+        ],
+    )
+    def test_redis_socket_timeout_parsing(self, value: object, expected: datetime.timedelta | None) -> None:
+        """Test that an unset or empty redis socket_timeout is treated as not set."""
+        assert RedisSettings(socket_timeout=value).socket_timeout == expected
+
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [
+            (None, None),
+            ("", None),
+            ("5", datetime.timedelta(seconds=5)),
+            ("PT10S", datetime.timedelta(seconds=10)),
+        ],
+    )
+    def test_redis_timeout_parsing(self, value: object, expected: datetime.timedelta | None) -> None:
+        """Test that an unset or empty redis timeout is treated as not set."""
+        assert RedisSettings(timeout=value).timeout == expected


### PR DESCRIPTION
## Summary

Use the c2casgiutils `Duration` type for the duration-based environment settings instead of raw `int` and `str` fields.

## Context

- The duration-like environment settings (`max_generation_time`, `postgresql.init_timeout`, `redis.timeout`, `redis.socket_timeout`) were typed as plain `int` or `str`, accepted only seconds and required ad-hoc conversions.
- c2casgiutils provides a pydantic `Duration` type (`Annotated[timedelta, BeforeValidator(parse_duration)]`) that accepts ISO 8601 durations (`PT1M`), the short format (`2m30`, `1h`) and plain seconds.

## Implementation Details

- `max_generation_time` and `init_timeout` now use `Duration` with defaults `timedelta(seconds=60)` / `timedelta(seconds=30)`.
- `redis.timeout` and `redis.socket_timeout` use an `OptionalDuration` variant that keeps treating empty values as unset (previous behavior with `str | None`).
- Values are converted to seconds with `.total_seconds()` at the boundaries where a plain number is required: the redis-py lock timeout, the tilecloud `RedisTileStore` timeout and `asyncio.wait_for`.
- Documentation updated in `USAGE.rst` (including the previously undocumented redis timeout variables), `SETTINGS.md` regenerated and a CHANGELOG entry added.

## Impact/Risks

- Backward compatible for environment values: plain numbers are still interpreted as seconds.
- The Python type of these settings changes from `int`/`str` to `datetime.timedelta` for direct consumers of `tilecloud_chain.settings`.


<!-- pull request links -->
See JIRA issue: [GSGMF-1746](https://camptocamp.atlassian.net/browse/GSGMF-1746).

[GSGMF-1746]: https://camptocamp.atlassian.net/browse/GSGMF-1746?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ